### PR TITLE
Add coercions

### DIFF
--- a/lib/drops/coercions.ex
+++ b/lib/drops/coercions.ex
@@ -1,0 +1,4 @@
+defmodule Drops.Coercions do
+  def coerce(:string, :integer, value), do: String.to_integer(value)
+  def coerce(:integer, :string, value), do: to_string(value)
+end

--- a/lib/drops/contract/dsl.ex
+++ b/lib/drops/contract/dsl.ex
@@ -3,8 +3,24 @@ defmodule Drops.Contract.DSL do
     {:required, name}
   end
 
-  def type(type, predicates \\ []) do
+  def from(type) do
+    {:coerce, type}
+  end
+
+  def type(type, predicates) when is_list(predicates) do
     [predicate(:type?, type) | Enum.map(predicates, &predicate/1)]
+  end
+
+  def type({:coerce, input_type}, output_type) when is_atom(output_type) do
+    {:coerce, input_type, output_type, type(input_type), type(output_type)}
+  end
+
+  def type({:coerce, input_type}, output_type, predicates) do
+    {:coerce, input_type, output_type, type(input_type), type(output_type, predicates)}
+  end
+
+  def type(type) when is_atom(type) do
+    [predicate(:type?, type)]
   end
 
   def predicate(name, args \\ []) do

--- a/test/contract/coercions_test.exs
+++ b/test/contract/coercions_test.exs
@@ -1,0 +1,28 @@
+defmodule Drops.CoercionTest do
+  use ExUnit.Case
+
+  describe "schema" do
+    setup(_) do
+      on_exit(fn ->
+        :code.purge(Drops.CoercionTest.TestContract)
+        :code.delete(Drops.CoercionTest.TestContract)
+      end)
+    end
+
+    test "defining a required key with coercion" do
+      defmodule TestContract do
+        use Drops.Contract
+
+        schema do
+          %{
+            required(:code) => from(:integer) |> type(:string),
+            required(:price) => from(:string) |> type(:integer)
+          }
+        end
+      end
+
+      assert {:ok, %{code: "12", price: 11}} =
+               TestContract.conform(%{code: 12, price: "11"})
+    end
+  end
+end


### PR DESCRIPTION
This adds a basic support for coercion functions. The DSL allows you to define from which type you want to coerce and what should be the resulting type. Additional constraints for the input type are not added at this point, but it's as good starting point.

```elixir
defmodule TestContract do
  use Drops.Contract

  schema do
    %{
      required(:code) => from(:integer) |> type(:string),
      required(:price) => from(:string) |> type(:integer)
    }
  end
end

TestContract.conform(%{code: 12, price: "11"})
# {:ok, %{code: "12", price: 11}}

TestContract.conform(%{code: 12, price: 11})  
# {:error, [error: {:string?, :price, 11}]}
```