### PR TITLE
Add `rule` macro

### DIFF
--- a/test/contract/contract_test.exs
+++ b/test/contract/contract_test.exs
@@ -141,5 +141,29 @@ defmodule DropsTest do
                  }
                })
     end
+
+    test "defining a schema with rules" do
+      defmodule TestContract do
+        use Drops.Contract
+
+        schema do
+          %{
+            required(:name) => type(:string, [:filled?])
+          }
+        end
+
+        rule(:unique?, [{:ok, {:name, value}}]) do
+          case value do
+            "John" -> {:error, {:taken, :name, value}}
+            _ -> :ok
+          end
+        end
+      end
+
+      assert {:ok, %{name: "Jane"}} = TestContract.conform(%{name: "Jane"})
+
+      assert {:error, [{:error, {:taken, :name, "John"}}]} =
+               TestContract.conform(%{name: "John"})
+    end
   end
 end


### PR DESCRIPTION
This adds support for defining arbitrary rule functions that match against input that was already processed and validated by the contract's schema. This allows you to define additional validation logic that can be implemented in a type-safe fashion.

```elixir
defmodule TestContract do
  use Drops.Contract

  schema do
    %{
      required(:name) => type(:string, [:filled?])
    }
  end

  rule(:unique?, [{:ok, {:name, value}}]) do
    case value do
      "John" -> {:error, {:taken, :name, value}}
      _ -> :ok
    end
  end
end

TestContract.conform(%{name: "Jane"})
# {:ok, %{name: "Jane"}}

TestContract.conform(%{name: "John"})
# {:error, [error: {:taken, :name, "John"}]}
```