### PR TITLE
Add `optional` to the DSL

### DIFF
--- a/lib/drops/contract.ex
+++ b/lib/drops/contract.ex
@@ -33,6 +33,14 @@ defmodule Drops.Contract do
         end
       end
 
+      def validate(data, {{:optional, name}, predicates}) do
+        if Map.has_key?(data, name) do
+          validate(data[name], predicates, path: name)
+        else
+          :ok
+        end
+      end
+
       def validate(
             value,
             {:coerce, input_type, output_type, input_predicates, output_predicates},
@@ -121,8 +129,11 @@ defmodule Drops.Contract do
       end
 
       def to_output(results) do
-        Enum.reduce(results, %{}, fn {:ok, {path, value}}, acc ->
-          put_in(acc, List.flatten([path]), value)
+        Enum.reduce(results, %{}, fn result, acc ->
+          case result do
+            {:ok, {path, value}} -> put_in(acc, List.flatten([path]), value)
+            :ok -> acc
+          end
         end)
       end
     end

--- a/lib/drops/contract/dsl.ex
+++ b/lib/drops/contract/dsl.ex
@@ -3,6 +3,10 @@ defmodule Drops.Contract.DSL do
     {:required, name}
   end
 
+  def optional(name) do
+    {:optional, name}
+  end
+
   def from(type) do
     {:coerce, type}
   end

--- a/test/contract/contract_test.exs
+++ b/test/contract/contract_test.exs
@@ -36,6 +36,30 @@ defmodule DropsTest do
       assert Enum.member?(result, {:error, {:integer?, :age, "21"}})
     end
 
+    test "defining required and optionals keys with types" do
+      defmodule TestContract do
+        use Drops.Contract
+
+        schema do
+          %{
+            required(:email) => type(:string, [:filled?]),
+            optional(:name) => type(:string, [:filled?])
+          }
+        end
+      end
+
+      assert {:error, [{:error, {:has_key?, :email}}]} = TestContract.conform(%{})
+
+      assert {:error, [{:error, {:filled?, :name, ""}}, {:error, {:filled?, :email, ""}}]} =
+               TestContract.conform(%{email: "", name: ""})
+
+      assert {:error, [{:error, {:filled?, :name, ""}}]} =
+               TestContract.conform(%{email: "jane@doe.org", name: ""})
+
+      assert {:ok, %{email: "jane@doe.org", name: "Jane"}} =
+               TestContract.conform(%{email: "jane@doe.org", name: "Jane"})
+    end
+
     test "defining required keys with types and extra predicates" do
       defmodule TestContract do
         use Drops.Contract


### PR DESCRIPTION
This adds support for defining *optional* keys. Such keys can be omitted and it won't cause any validation errors.

```elixir
defmodule TestContract do
  use Drops.Contract

  schema do
    %{
      required(:email) => type(:string, [:filled?]),
      optional(:name) => type(:string, [:filled?])
    }
  end
end
      
TestContract.conform(%{})
# {:error, [error: {:has_key?, :email}]}

TestContract.conform(%{email: "", name: ""})
# {:error, [error: {:filled?, :name, ""}, error: {:filled?, :email, ""}]}

TestContract.conform(%{email: "jane@doe.org", name: ""})
# {:error, [error: {:filled?, :name, ""}]}

TestContract.conform(%{email: "jane@doe.org"})
# {:ok, %{email: "jane@doe.org"}}

TestContract.conform(%{email: "jane@doe.org", name: "Jane"})
# {:ok, %{name: "Jane", email: "jane@doe.org"}}
```