### PR TITLE
Support for string maps

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
 # Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  line_length: 90,
+  line_length: 90
 ]

--- a/lib/drops/contract.ex
+++ b/lib/drops/contract.ex
@@ -18,11 +18,15 @@ defmodule Drops.Contract do
       end
 
       def conform(data, %Schema{atomize: true} = schema) do
-        conform(Schema.atomize(data, schema), schema)
+        conform(Schema.atomize(data, schema.keys), schema.plan)
       end
 
-      def conform(data, schema) do
-        results = Enum.map(schema.plan, &step(data, &1)) |> List.flatten() |> apply_rules()
+      def conform(data, %Schema{} = schema) do
+        conform(data, schema.plan)
+      end
+
+      def conform(data, plan) do
+        results = Enum.map(plan, &step(data, &1)) |> List.flatten() |> apply_rules()
 
         if Enum.all?(results, &is_ok/1) do
           {:ok, to_output(results)}

--- a/lib/drops/contract/schema.ex
+++ b/lib/drops/contract/schema.ex
@@ -1,0 +1,64 @@
+defmodule Drops.Contract.Schema do
+  alias __MODULE__
+
+  defstruct [:keys, :plan]
+
+  defmodule Key do
+    defstruct [:path, :presence, :predicates, children: []]
+
+    def present?(map, _) when not is_map(map) do
+      true
+    end
+
+    def present?(_map, []) do
+      true
+    end
+
+    def present?(map, %Key{} = key) do
+      present?(map, key.path)
+    end
+
+    def present?(map, [key | tail]) do
+      Map.has_key?(map, key) and present?(map[key], tail)
+    end
+  end
+
+  def new(map, opts) do
+    keys = to_key_list(map)
+
+    %Schema{keys: keys, plan: build_plan(keys)}
+  end
+
+  defp to_key_list(map, root \\ []) do
+    Enum.map(map, fn {{presence, name}, value} ->
+      case value do
+        %{} ->
+          build_key(
+            presence,
+            root ++ [name],
+            [{:predicate, {:type?, :map}}],
+            to_key_list(value, root ++ [name])
+          )
+
+        _ ->
+          build_key(presence, root ++ [name], value)
+      end
+    end)
+  end
+
+  defp build_key(presence, path, predicates, children \\ []) do
+    %Key{path: path, presence: presence, predicates: predicates, children: children}
+  end
+
+  defp build_plan(keys) do
+    Enum.map(keys, &key_step/1)
+  end
+
+  defp key_step(%{children: children} = key) when length(children) > 0 do
+    {:and, [{:validate, key}, build_plan(children)]}
+  end
+
+  defp key_step(key) do
+    {:validate, key}
+  end
+end

--- a/test/contract/contract_test.exs
+++ b/test/contract/contract_test.exs
@@ -195,4 +195,68 @@ defmodule Drops.ContractTest do
                contract.conform(%{name: "John"})
     end
   end
+
+  describe "schema for string maps" do
+    contract do
+      schema(atomize: true) do
+        %{
+          required(:user) => %{
+            required(:name) => type(:string, [:filled?]),
+            required(:age) => type(:integer),
+            required(:address) => %{
+              required(:city) => type(:string, [:filled?]),
+              required(:street) => type(:string, [:filled?]),
+              required(:zipcode) => type(:string, [:filled?])
+            }
+          }
+        }
+      end
+    end
+
+    test "returns success when schema validation passed", %{contract: contract} do
+      expected_output = %{
+                user: %{
+                  name: "John",
+                  age: 21,
+                  address: %{
+                    city: "New York",
+                    street: "Central Park",
+                    zipcode: "10001"
+                  }
+                }
+              }
+
+      assert {:ok, output} =
+               contract.conform(%{
+                 "user" => %{
+                   "name" => "John",
+                   "age" => 21,
+                   "address" => %{
+                     "city" => "New York",
+                     "street" => "Central Park",
+                     "zipcode" => "10001"
+                   }
+                 }
+               })
+
+      assert expected_output == output
+
+      assert {:error,
+              [
+                {:error, {:filled?, [:user, :address, :street], ""}},
+                {:error, {:filled?, [:user, :name], ""}}
+              ]} =
+               contract.conform(%{
+                 "user" => %{
+                   "name" => "",
+                   "age" => 21,
+                   "address" => %{
+                     "city" => "New York",
+                     "street" => "",
+                     "zipcode" => "10001"
+                   }
+                 }
+               })
+    end
+  end
 end

--- a/test/contract/predicates_test.exs
+++ b/test/contract/predicates_test.exs
@@ -13,7 +13,8 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {:string?, [:test], 312}}]} = contract.conform(%{test: 312})
+      assert {:error, [{:error, {:string?, [:test], 312}}]} =
+               contract.conform(%{test: 312})
     end
   end
 
@@ -29,7 +30,8 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-integer value", %{contract: contract} do
-      assert {:error, [{:error, {:integer?, [:test], "Hello"}}]} = contract.conform(%{test: "Hello"})
+      assert {:error, [{:error, {:integer?, [:test], "Hello"}}]} =
+               contract.conform(%{test: "Hello"})
     end
   end
 

--- a/test/contract/predicates_test.exs
+++ b/test/contract/predicates_test.exs
@@ -13,7 +13,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {:string?, :test, 312}}]} = contract.conform(%{test: 312})
+      assert {:error, [{:error, {:string?, [:test], 312}}]} = contract.conform(%{test: 312})
     end
   end
 
@@ -29,7 +29,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-integer value", %{contract: contract} do
-      assert {:error, [{:error, {:integer?, :test, "Hello"}}]} = contract.conform(%{test: "Hello"})
+      assert {:error, [{:error, {:integer?, [:test], "Hello"}}]} = contract.conform(%{test: "Hello"})
     end
   end
 
@@ -45,7 +45,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-map value", %{contract: contract} do
-      assert {:error, [{:error, {:map?, :test, 312}}]} = contract.conform(%{test: 312})
+      assert {:error, [{:error, {:map?, [:test], 312}}]} = contract.conform(%{test: 312})
     end
   end
 
@@ -61,7 +61,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with an empty string", %{contract: contract} do
-      assert {:error, [{:error, {:filled?, :test, ""}}]} = contract.conform(%{test: ""})
+      assert {:error, [{:error, {:filled?, [:test], ""}}]} = contract.conform(%{test: ""})
     end
   end
 end


### PR DESCRIPTION
This adds `atomize: true | false` option to `schema` DSL which can be used to have string-based maps turned into atom-based maps:

```elixir
defmodule TestContract do
  use Drops.Contract

  schema(atomize: true) do
    %{
      required(:user) => %{
        required(:name) => type(:string, [:filled?]),
        required(:age) => type(:integer),
        required(:address) => %{
          required(:city) => type(:string, [:filled?]),
          required(:street) => type(:string, [:filled?]),
          required(:zipcode) => type(:string, [:filled?])
        }
      }
    }
  end
end

TestContract.conform(%{
 "user" => %{
   "name" => "John",
   "age" => 21,
   "address" => %{
     "city" => "New York",
     "street" => "Central Park",
     "zipcode" => "10001"
   }
 }
})
# {:ok,
#  %{
#    user: %{
#      name: "John",
#      address: %{city: "New York", street: "Central Park", zipcode: "10001"},
#      age: 21
#    }
#  }}
```