### PR TITLE
17 support multiple types

### DIFF
--- a/lib/drops/contract/dsl.ex
+++ b/lib/drops/contract/dsl.ex
@@ -11,23 +11,15 @@ defmodule Drops.Contract.DSL do
     {:coerce, type}
   end
 
+  def type(type) do
+    {:type, {type, []}}
+  end
+
   def type(type, predicates) when is_list(predicates) do
-    [predicate(:type?, type) | Enum.map(predicates, &predicate/1)]
+    {:type, {type, predicates}}
   end
 
-  def type({:coerce, input_type}, output_type) when is_atom(output_type) do
-    {:coerce, input_type, output_type, type(input_type), type(output_type)}
-  end
-
-  def type({:coerce, input_type}, output_type, predicates) do
-    {:coerce, input_type, output_type, type(input_type), type(output_type, predicates)}
-  end
-
-  def type(type) when is_atom(type) do
-    [predicate(:type?, type)]
-  end
-
-  def predicate(name, args \\ []) do
-    {:predicate, {name, args}}
+  def type({:coerce, input_type}, output_type) do
+    {:coerce, {type(input_type), type(output_type)}}
   end
 end

--- a/lib/drops/contract/dsl.ex
+++ b/lib/drops/contract/dsl.ex
@@ -11,6 +11,14 @@ defmodule Drops.Contract.DSL do
     {:coerce, type}
   end
 
+  def type({type, predicates}) when is_atom(type) do
+    type(type, predicates)
+  end
+
+  def type(types) when is_list(types) do
+    Enum.map(types, &type/1)
+  end
+
   def type(type) do
     {:type, {type, []}}
   end

--- a/lib/drops/contract/schema/key.ex
+++ b/lib/drops/contract/schema/key.ex
@@ -1,0 +1,52 @@
+defmodule Drops.Contract.Schema.Key do
+  alias __MODULE__
+
+  defstruct [:path, :presence, :type, :predicates, children: []]
+
+  def new(spec, attrs) do
+    Map.merge(
+      %Key{},
+      Enum.into(attrs, %{type: infer_type(spec), predicates: infer_predicates(spec)})
+    )
+  end
+
+  def present?(map, _) when not is_map(map) do
+    true
+  end
+
+  def present?(_map, []) do
+    true
+  end
+
+  def present?(map, %Key{} = key) do
+    present?(map, key.path)
+  end
+
+  def present?(map, [key | tail]) do
+    Map.has_key?(map, key) and present?(map[key], tail)
+  end
+
+  defp infer_type({:type, {type, _}}) do
+    type
+  end
+
+  defp infer_type({:coerce, {input_type, output_type}}) do
+    {:coerce, {{infer_type(input_type), infer_predicates(input_type)}, infer_type(output_type)}}
+  end
+
+  defp infer_predicates({:coerce, {_input_type, output_type}}) do
+    infer_predicates(output_type)
+  end
+
+  defp infer_predicates({:type, {type, predicates}}) do
+    [predicate(:type?, type) | Enum.map(predicates, &predicate/1)]
+  end
+
+  defp predicate(name, args) do
+    {:predicate, {name, args}}
+  end
+
+  defp predicate(name) do
+    {:predicate, {name, []}}
+  end
+end

--- a/test/contract/type_test.exs
+++ b/test/contract/type_test.exs
@@ -1,0 +1,59 @@
+defmodule Drops.Contract.TypeTest do
+  use Drops.ContractCase
+
+  describe "type/1 with a type atom" do
+    contract do
+      schema do
+        %{required(:test) => type(:string)}
+      end
+    end
+
+    test "returns success with valid data", %{contract: contract} do
+      assert {:ok, %{test: "Hello"}} = contract.conform(%{test: "Hello"})
+    end
+
+    test "returns error with invalid data", %{contract: contract} do
+      assert {:error, [{:error, {:string?, [:test], 312}}]} =
+               contract.conform(%{test: 312})
+    end
+  end
+
+  describe "type/1 with multiple types" do
+    contract do
+      schema do
+        %{required(:test) => type([:integer, :string])}
+      end
+    end
+
+    test "returns success with valid data", %{contract: contract} do
+      assert {:ok, %{test: 312}} = contract.conform(%{test: 312})
+      assert {:ok, %{test: "Hello"}} = contract.conform(%{test: "Hello"})
+    end
+
+    test "returns error with invalid data", %{contract: contract} do
+      assert {:error, [{:error, {:string?, [:test], :invalid}}]} =
+               contract.conform(%{test: :invalid})
+    end
+  end
+
+  describe "type/1 with multiple types and extra predicates" do
+    contract do
+      schema do
+        %{required(:test) => type([:integer, {:string, [:filled?]}])}
+      end
+    end
+
+    test "returns success with valid data", %{contract: contract} do
+      assert {:ok, %{test: 312}} = contract.conform(%{test: 312})
+      assert {:ok, %{test: "Hello"}} = contract.conform(%{test: "Hello"})
+    end
+
+    test "returns error with invalid data", %{contract: contract} do
+      assert {:error, [{:error, {:string?, [:test], :invalid}}]} =
+               contract.conform(%{test: :invalid})
+
+      assert {:error, [{:error, {:filled?, [:test], ""}}]} =
+               contract.conform(%{test: ""})
+    end
+  end
+end


### PR DESCRIPTION
This adds support for defining a value that can have multiple types. You can also specify any extra constraints that should be applied:

```elixir
defmodule TestContract do
  use Drops.Contract

  schema do
    %{required(:test) => type([:integer, {:string, [:filled?]}])}
  end
end

TestContract.conform(%{test: 312})
# {:ok, %{test: 312}}

TestContract.conform(%{test: "Hello"})
# {:ok, %{test: "Hello"}}

TestContract.conform(%{test: :invalid})
# {:error, [error: {:string?, [:test], :invalid}]}

TestContract.conform(%{test: :invalid})
# {:error, [error: {:filled?, [:test], ""}]}
```

Closes #17 