### PR TITLE
Add integer => date_time caster

### DIFF
--- a/lib/drops/casters.ex
+++ b/lib/drops/casters.ex
@@ -7,4 +7,7 @@ defmodule Drops.Casters do
   end
 
   def cast(:integer, :string, value), do: to_string(value)
+
+  def cast(:integer, :date_time, value, unit \\ :second),
+    do: DateTime.from_unix!(value, unit)
 end

--- a/lib/drops/contract.ex
+++ b/lib/drops/contract.ex
@@ -79,7 +79,7 @@ defmodule Drops.Contract do
         case apply_predicates(value, input_predicates, path: key.path) do
           {:ok, _} ->
             validate(
-              caster.cast(input_type, output_type, value),
+              apply(caster, :cast, [input_type, output_type, value] ++ cast_opts),
               key.predicates,
               path: key.path
             )

--- a/test/contract/casters_test.exs
+++ b/test/contract/casters_test.exs
@@ -37,10 +37,40 @@ defmodule Drops.CastersTest do
     end
   end
 
+  describe ":integer => :date_time" do
+    contract do
+      schema do
+        %{required(:test) => from(:integer) |> type(:date_time)}
+      end
+    end
+
+    test "defining a required key with coercion", %{contract: contract} do
+      timestamp = 1695277470
+      date_time = DateTime.from_unix!(timestamp, :second)
+
+      assert {:ok, %{test: ^date_time}} = contract.conform(%{test: timestamp})
+    end
+  end
+
+  describe ":integer => :date_time with :milliseconds" do
+    contract do
+      schema do
+        %{required(:test) => from(:integer, [:millisecond]) |> type(:date_time)}
+      end
+    end
+
+    test "defining a required key with coercion", %{contract: contract} do
+      timestamp = 1695277723355
+      date_time = DateTime.from_unix!(timestamp, :millisecond)
+
+      assert {:ok, %{test: ^date_time}} = contract.conform(%{test: timestamp})
+    end
+  end
+
   describe "using a customer caster" do
     contract do
       defmodule CustomCaster do
-        def cast(:string, :string, value) do
+        def cast(:string, :string, value, _opts) do
           String.downcase(value)
         end
       end


### PR DESCRIPTION
Using the default `:second` unit:

```elixir
defmodule TestContract do
  use Drops.Contract
  
  schema do
    %{required(:test) => from(:integer) |> type(:date_time)}
  end
end

TestContract.conform(%{test: 1695277470})
# {:ok, %{test: ~U[2023-09-21 06:24:30Z]}}
```


Providing time unit as an argument for the casting function:

```elixir
defmodule TestContract do
  use Drops.Contract
  
  schema do
    %{required(:test) => from(:integer, [:millisecond]) |> type(:date_time)}
  end
end

TestContract.conform(%{test: 1695277723355})
# {:ok, %{test: ~U[2023-09-21 06:28:43.355Z]}}
```

Closes #10 