### PR TITLE
Add maybe

### DIFF
--- a/lib/drops/contract/dsl.ex
+++ b/lib/drops/contract/dsl.ex
@@ -42,4 +42,8 @@ defmodule Drops.Contract.DSL do
   def list(type, predicates \\ []) do
     type(list: [type | predicates])
   end
+
+  def maybe(type, predicates \\ []) do
+    type([:nil, [{type, predicates}]])
+  end
 end

--- a/test/contract/maybe_test.exs
+++ b/test/contract/maybe_test.exs
@@ -1,0 +1,50 @@
+defmodule Drops.MaybeTest do
+  use Drops.ContractCase
+
+  describe "maybe/1 with :string" do
+    contract do
+      schema do
+        %{required(:test) => maybe(:string)}
+      end
+    end
+
+    test "returns success with nil", %{contract: contract} do
+      assert {:ok, _} = contract.conform(%{test: nil})
+    end
+
+    test "returns success with a string value", %{contract: contract} do
+      assert {:ok, _} = contract.conform(%{test: "hello"})
+    end
+
+    test "returns error with a non-string value", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :type?, [:string, 312]}}]} =
+               contract.conform(%{test: 312})
+    end
+  end
+
+  describe "maybe/1 with :string and extra predicates" do
+    contract do
+      schema do
+        %{required(:test) => maybe(:string, [:filled?])}
+      end
+    end
+
+    test "returns success with nil", %{contract: contract} do
+      assert {:ok, _} = contract.conform(%{test: nil})
+    end
+
+    test "returns success with a string value", %{contract: contract} do
+      assert {:ok, _} = contract.conform(%{test: "hello"})
+    end
+
+    test "returns error with a non-string value", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :type?, [:string, 312]}}]} =
+               contract.conform(%{test: 312})
+    end
+
+    test "returns error when extra predicates fail", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :filled?, [""]}}]} =
+               contract.conform(%{test: ""})
+    end
+  end
+end


### PR DESCRIPTION
This adds a new DSL function called `maybe` which allows you to define a type that can be either `nil` or the type that is passed to the maybe function:

```elixir
defmodule TestContract do
  use Drops.Contract
  
  schema do
    %{required(:test) => maybe(:string)}
  end
end

TestContract.conform(%{test: nil})
# {:ok, %{test: nil}}

TestContract.conform(%{test: "Hello"})
# {:ok, %{test: "Hello"}}

TestContract.conform(%{test: 312})    
# {:error, [error: {[:test], :type?, [:string, 312]}]}
```

You can also use any extra predicates for the non-nil type checks:

```elixir
defmodule TestContract do
  use Drops.Contract
  
  schema do
    %{required(:test) => maybe(:string, [:filled?])}
  end
end

TestContract.conform(%{test: nil})
# {:ok, %{test: nil}}

TestContract.conform(%{test: "Hello"})
# {:ok, %{test: "Hello"}}

TestContract.conform(%{test: ""})    
# {:error, [error: {[:test], :filled?, [""]}]}
```