### PR TITLE
Type shortcuts

### DIFF
--- a/lib/drops/contract/dsl.ex
+++ b/lib/drops/contract/dsl.ex
@@ -74,4 +74,16 @@ defmodule Drops.Contract.DSL do
   def integer(predicates) when is_list(predicates) do
     type(:integer, predicates)
   end
+
+  def map() do
+    type(:map)
+  end
+
+  def map(predicate) when is_atom(predicate) do
+    map([predicate])
+  end
+
+  def map(predicates) when is_list(predicates) do
+    type(:map, predicates)
+  end
 end

--- a/lib/drops/contract/dsl.ex
+++ b/lib/drops/contract/dsl.ex
@@ -62,4 +62,16 @@ defmodule Drops.Contract.DSL do
   def string(predicates) when is_list(predicates) do
     type(:string, predicates)
   end
+
+  def integer() do
+    type(:integer)
+  end
+
+  def integer(predicate) when is_atom(predicate) do
+    integer([predicate])
+  end
+
+  def integer(predicates) when is_list(predicates) do
+    type(:integer, predicates)
+  end
 end

--- a/lib/drops/contract/dsl.ex
+++ b/lib/drops/contract/dsl.ex
@@ -50,4 +50,16 @@ defmodule Drops.Contract.DSL do
   def maybe(type, predicates \\ []) do
     type([:nil, [{type, predicates}]])
   end
+
+  def string() do
+    type(:string)
+  end
+
+  def string(predicate) when is_atom(predicate) do
+    string([predicate])
+  end
+
+  def string(predicates) when is_list(predicates) do
+    type(:string, predicates)
+  end
 end

--- a/test/contract/types/integer_test.exs
+++ b/test/contract/types/integer_test.exs
@@ -1,0 +1,83 @@
+defmodule Drops.Contract.Types.IntegerTest do
+  use Drops.ContractCase
+
+  describe "integer/0" do
+    contract do
+      schema do
+        %{required(:test) => integer()}
+      end
+    end
+
+    test "returns success with valid data", %{contract: contract} do
+      assert {:ok, %{test: 312}} = contract.conform(%{test: 312})
+    end
+
+    test "returns error with invalid data", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :type?, [:integer, :invalid]}}]} =
+               contract.conform(%{test: :invalid})
+    end
+  end
+
+  describe "integer/1 with an extra predicate" do
+    contract do
+      schema do
+        %{required(:test) => integer(:odd?)}
+      end
+    end
+
+    test "returns success with valid data", %{contract: contract} do
+      assert {:ok, %{test: 311}} = contract.conform(%{test: 311})
+    end
+
+    test "returns error with invalid data", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :type?, [:integer, :invalid]}}]} =
+               contract.conform(%{test: :invalid})
+
+      assert {:error, [{:error, {[:test], :odd?, [312]}}]} =
+               contract.conform(%{test: 312})
+    end
+  end
+
+  describe "integer/1 with an extra predicate with args" do
+    contract do
+      schema do
+        %{required(:test) => integer(gt?: 2)}
+      end
+    end
+
+    test "returns success with valid data", %{contract: contract} do
+      assert {:ok, %{test: 312}} = contract.conform(%{test: 312})
+    end
+
+    test "returns error with invalid data", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :type?, [:integer, :invalid]}}]} =
+               contract.conform(%{test: :invalid})
+
+      assert {:error, [{:error, {[:test], :gt?, [2, 0]}}]} =
+               contract.conform(%{test: 0})
+    end
+  end
+
+  describe "integer/1 with extra predicates" do
+    contract do
+      schema do
+        %{required(:test) => integer([:even?, gt?: 2])}
+      end
+    end
+
+    test "returns success with valid data", %{contract: contract} do
+      assert {:ok, %{test: 312}} = contract.conform(%{test: 312})
+    end
+
+    test "returns error with invalid data", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :type?, [:integer, :invalid]}}]} =
+               contract.conform(%{test: :invalid})
+
+      assert {:error, [{:error, {[:test], :even?, [7]}}]} =
+               contract.conform(%{test: 7})
+
+      assert {:error, [{:error, {[:test], :gt?, [2, 0]}}]} =
+               contract.conform(%{test: 0})
+    end
+  end
+end

--- a/test/contract/types/map_test.exs
+++ b/test/contract/types/map_test.exs
@@ -1,0 +1,37 @@
+defmodule Drops.Contract.Types.MapTest do
+  use Drops.ContractCase
+
+  describe "map/0" do
+    contract do
+      schema do
+        %{required(:test) => map()}
+      end
+    end
+
+    test "returns success with a map value", %{contract: contract} do
+      assert {:ok, _} = contract.conform(%{test: %{}})
+    end
+
+    test "returns error with a non-map value", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :type?, [:map, 312]}}]} =
+               contract.conform(%{test: 312})
+    end
+  end
+
+  describe "map/1 with extra predicates" do
+    contract do
+      schema do
+        %{required(:test) => map(:filled?)}
+      end
+    end
+
+    test "returns success with a map value", %{contract: contract} do
+      assert {:ok, _} = contract.conform(%{test: %{hello: "World"}})
+    end
+
+    test "returns error with a non-map value", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :filled?, [%{}]}}]} =
+               contract.conform(%{test: %{}})
+    end
+  end
+end

--- a/test/contract/types/string_test.exs
+++ b/test/contract/types/string_test.exs
@@ -1,0 +1,36 @@
+defmodule Drops.Contract.Types.StringTest do
+  use Drops.ContractCase
+
+  describe "string/0" do
+    contract do
+      schema do
+        %{required(:test) => string()}
+      end
+    end
+
+    test "returns success with a string value", %{contract: contract} do
+      assert {:ok, _} = contract.conform(%{test: "Hello"})
+    end
+
+    test "returns error with a non-string value", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :type?, [:string, 312]}}]} =
+               contract.conform(%{test: 312})
+    end
+  end
+
+  describe "string/1 with extra predicates" do
+    contract do
+      schema do
+        %{required(:test) => string(:filled?)}
+      end
+    end
+
+    test "returns success with a non-empty string", %{contract: contract} do
+      assert {:ok, %{test: "Hello"}} = contract.conform(%{test: "Hello"})
+    end
+
+    test "returns error with an empty string", %{contract: contract} do
+      assert {:error, [{:error, {[:test], :filled?, [""]}}]} = contract.conform(%{test: ""})
+    end
+  end
+end


### PR DESCRIPTION
This adds convenient type-check shortcuts:

```elixir
%{
  # translates to required(:test) => type(:string)
  required(:test) => string(),

  # translates to required(:test) => type(:integer)
  required(:test) => integer(),

  # translates to required(:test) => type(:map)
  required(:test) => map()
}
```

You can use regular predicate syntax with these shortcuts too:

```elixir
%{
  # translates to required(:test) => type(:string, [:filled?])
  required(:test) => string(:filled?),

  # translates to required(:test) => type(:integer, [:even?, gt?: 2])
  required(:test) => integer([:even?, gt?: 2]),

  # translates to required(:test) => type(:map, size?: 3)
  required(:test) => map(size?: 3)
}
```