### PR TITLE
Add first class types

### DIFF
--- a/lib/drops/contract.ex
+++ b/lib/drops/contract.ex
@@ -2,9 +2,9 @@ defmodule Drops.Contract do
   defmacro __using__(_opts) do
     quote do
       alias Drops.{Casters, Predicates}
-      alias Drops.Contract.Key
-      alias Drops.Contract.Schema
-      alias Drops.Contract.Type
+      alias Drops.Type
+      alias Drops.Type.Schema
+      alias Drops.Type.Schema.Key
 
       import Drops.Contract
       import Drops.Contract.Runtime
@@ -264,7 +264,7 @@ defmodule Drops.Contract do
 
   defp set_schema(_caller, opts, block) do
     quote do
-      alias Drops.Contract.Schema
+      alias Drops.Type.Schema
 
       mod = __MODULE__
 

--- a/lib/drops/contract.ex
+++ b/lib/drops/contract.ex
@@ -2,8 +2,8 @@ defmodule Drops.Contract do
   defmacro __using__(_opts) do
     quote do
       alias Drops.{Casters, Predicates}
+      alias Drops.Contract.Key
       alias Drops.Contract.Schema
-      alias Drops.Contract.Schema.Key
 
       import Drops.Contract
       import Drops.Contract.Runtime

--- a/lib/drops/contract/dsl.ex
+++ b/lib/drops/contract/dsl.ex
@@ -48,7 +48,7 @@ defmodule Drops.Contract.DSL do
   end
 
   def maybe(type, predicates \\ []) do
-    type([:nil, [{type, predicates}]])
+    type([:nil, {type, predicates}])
   end
 
   def string() do

--- a/lib/drops/contract/key.ex
+++ b/lib/drops/contract/key.ex
@@ -1,17 +1,15 @@
 defmodule Drops.Contract.Key do
   alias __MODULE__
-  alias Drops.Contract.Schema
+  alias Drops.Contract.Type
 
-  defstruct [:path, :presence, :type, :predicates, children: []]
+  defstruct [:path, :presence, :type]
+
+  def stringify(key) do
+    %Key{path: Enum.map(key.path, &to_string/1), presence: key.presence, type: key.type}
+  end
 
   def new(spec, opts, attrs) do
-    Map.merge(
-      %Key{},
-      Enum.into(attrs, %{
-        type: infer_type(spec, opts),
-        predicates: infer_predicates(spec, opts)
-      })
-    )
+    Map.merge(%Key{}, Enum.into(attrs, %{type: Type.new(spec, opts)}))
   end
 
   def present?(map, _) when not is_map(map) do
@@ -28,59 +26,5 @@ defmodule Drops.Contract.Key do
 
   def present?(map, [key | tail]) do
     Map.has_key?(map, key) and present?(map[key], tail)
-  end
-
-  defp infer_type({:type, {type, _}}, _opts) do
-    type
-  end
-
-  defp infer_type(spec, opts) when is_list(spec) do
-    Enum.map(spec, &infer_type(&1, opts))
-  end
-
-  defp infer_type({:cast, {input_type, output_type, cast_opts}}, opts) do
-    {:cast,
-     {{infer_type(input_type, opts), infer_predicates(input_type, opts), cast_opts},
-      infer_type(output_type, opts)}}
-  end
-
-  defp infer_predicates({:cast, {_input_type, output_type, _cast_opts}}, opts) do
-    infer_predicates(output_type, opts)
-  end
-
-  defp infer_predicates(spec, opts) when is_map(spec) do
-    {:and, [predicate(:type?, :map), Schema.new(spec, opts)]}
-  end
-
-  defp infer_predicates(spec, opts) when is_list(spec) do
-    {:or, Enum.map(spec, &infer_predicates(&1, opts))}
-  end
-
-  defp infer_predicates({:type, {:list, []}}, _opts) do
-    [predicate(:type?, :list)]
-  end
-
-  defp infer_predicates({:type, {:list, member_type}}, opts) when not is_list(member_type) do
-    {:and, [predicate(:type?, :list), {:each, infer_predicates(member_type, opts)}]}
-  end
-
-  defp infer_predicates({:type, {type, predicates}}, _opts) when length(predicates) > 0 do
-    {:and, [predicate(:type?, type) | Enum.map(predicates, &predicate/1)]}
-  end
-
-  defp infer_predicates({:type, {type, []}}, _opts) do
-    [predicate(:type?, type)]
-  end
-
-  defp predicate({name, args}) do
-    predicate(name, args)
-  end
-
-  defp predicate(name) do
-    predicate(name, [])
-  end
-
-  defp predicate(name, args) do
-    {:predicate, {name, args}}
   end
 end

--- a/lib/drops/contract/key.ex
+++ b/lib/drops/contract/key.ex
@@ -1,4 +1,4 @@
-defmodule Drops.Contract.Schema.Key do
+defmodule Drops.Contract.Key do
   alias __MODULE__
   alias Drops.Contract.Schema
 

--- a/lib/drops/contract/schema.ex
+++ b/lib/drops/contract/schema.ex
@@ -5,7 +5,7 @@ defmodule Drops.Contract.Schema do
 
   import Type, only: [infer_constraints: 2]
 
-  defstruct [:primitive, :constraints, :keys, :plan, :atomize]
+  defstruct [:primitive, :constraints, :keys, :atomize]
 
   def new(spec, opts) do
     atomize = opts[:atomize] || false
@@ -15,8 +15,7 @@ defmodule Drops.Contract.Schema do
       primitive: :map,
       constraints: infer_constraints({:type, {:map, []}}, opts),
       atomize: atomize,
-      keys: keys,
-      plan: build_plan(keys)
+      keys: keys
     }
   end
 
@@ -36,17 +35,5 @@ defmodule Drops.Contract.Schema do
     Enum.map(spec, fn {{presence, name}, spec} ->
       Key.new(spec, opts, presence: presence, path: root ++ [name])
     end)
-  end
-
-  defp build_plan(keys) do
-    Enum.map(keys, &key_step/1)
-  end
-
-  defp key_step(%{children: children} = key) when length(children) > 0 do
-    {:and, [{:validate, key}, build_plan(children)]}
-  end
-
-  defp key_step(key) do
-    {:validate, key}
   end
 end

--- a/lib/drops/contract/schema.ex
+++ b/lib/drops/contract/schema.ex
@@ -1,6 +1,6 @@
 defmodule Drops.Contract.Schema do
   alias __MODULE__
-  alias Drops.Contract.Schema.Key
+  alias Drops.Contract.Key
 
   defstruct [:keys, :plan, :atomize]
 

--- a/lib/drops/contract/type.ex
+++ b/lib/drops/contract/type.ex
@@ -1,0 +1,80 @@
+defmodule Drops.Contract.Type do
+  alias __MODULE__
+  alias Drops.Contract.Schema
+
+  defstruct [:primitive, :constraints]
+
+  defmodule Cast do
+    defstruct [:input_type, :output_type, :opts]
+  end
+
+  defmodule Sum do
+    defstruct [:left, :right, :opts]
+  end
+
+  defmodule List do
+    defstruct [:primitive, :constraints, :member_type]
+  end
+
+  def new(%{} = spec, opts) do
+    Schema.new(spec, opts)
+  end
+
+  def new([left, right], opts) do
+    %Sum{left: new(left, opts), right: new(right, opts), opts: opts}
+  end
+
+  def new({:type, {:list, member_type}} = spec, opts)
+      when is_tuple(member_type) or is_map(member_type) do
+    %List{
+      primitive: :list,
+      constraints: infer_constraints(spec, opts),
+      member_type: new(member_type, opts)
+    }
+  end
+
+  def new({:cast, {input_type, output_type, cast_opts}}, opts) do
+    %Cast{
+      input_type: new(input_type, opts),
+      output_type: new(output_type, opts),
+      opts: cast_opts
+    }
+  end
+
+  def new(spec, opts) do
+    %Type{
+      primitive: infer_primitive(spec, opts),
+      constraints: infer_constraints(spec, opts)
+    }
+  end
+
+  def infer_primitive({:type, {type, _}}, _opts) do
+    type
+  end
+
+  def infer_constraints({:type, {:list, member_type}}, _opts)
+      when is_tuple(member_type) or is_map(member_type) do
+    [predicate(:type?, :list)]
+  end
+
+  def infer_constraints({:type, {type, predicates}}, _opts)
+      when length(predicates) > 0 do
+    {:and, [predicate(:type?, type) | Enum.map(predicates, &predicate/1)]}
+  end
+
+  def infer_constraints({:type, {type, []}}, _opts) do
+    [predicate(:type?, type)]
+  end
+
+  def predicate({name, args}) do
+    predicate(name, args)
+  end
+
+  def predicate(name) do
+    predicate(name, [])
+  end
+
+  def predicate(name, args) do
+    {:predicate, {name, args}}
+  end
+end

--- a/lib/drops/type.ex
+++ b/lib/drops/type.ex
@@ -1,6 +1,6 @@
-defmodule Drops.Contract.Type do
+defmodule Drops.Type do
   alias __MODULE__
-  alias Drops.Contract.Schema
+  alias Drops.Type.Schema
 
   defstruct [:primitive, :constraints]
 

--- a/lib/drops/type/schema.ex
+++ b/lib/drops/type/schema.ex
@@ -1,7 +1,7 @@
-defmodule Drops.Contract.Schema do
+defmodule Drops.Type.Schema do
   alias __MODULE__
-  alias Drops.Contract.Key
-  alias Drops.Contract.Type
+  alias Drops.Type
+  alias Schema.Key
 
   import Type, only: [infer_constraints: 2]
 

--- a/lib/drops/type/schema/key.ex
+++ b/lib/drops/type/schema/key.ex
@@ -1,6 +1,6 @@
-defmodule Drops.Contract.Key do
+defmodule Drops.Type.Schema.Key do
   alias __MODULE__
-  alias Drops.Contract.Type
+  alias Drops.Type
 
   defstruct [:path, :presence, :type]
 

--- a/test/contract/contract_test.exs
+++ b/test/contract/contract_test.exs
@@ -16,7 +16,7 @@ defmodule Drops.ContractTest do
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, {:has_key?, [:age]}}]} = contract.conform(%{name: "Jane"})
+      assert {:error, [{:error, {[], :has_key?, [:age]}}]} = contract.conform(%{name: "Jane"})
     end
 
     test "returns error with invalid data", %{contract: contract} do
@@ -48,7 +48,7 @@ defmodule Drops.ContractTest do
     end
 
     test "returns has_key? error when a required key is missing", %{contract: contract} do
-      assert {:error, [{:error, {:has_key?, [:email]}}]} = contract.conform(%{})
+      assert {:error, [{:error, {[], :has_key?, [:email]}}]} = contract.conform(%{})
     end
 
     test "returns predicate errors", %{contract: contract} do
@@ -94,7 +94,7 @@ defmodule Drops.ContractTest do
     end
 
     test "returns nested errors", %{contract: contract} do
-      assert {:error, [{:error, {:has_key?, [:user]}}]} = contract.conform(%{})
+      assert {:error, [{:error, {[], :has_key?, [:user]}}]} = contract.conform(%{})
 
       assert {:error, [{:error, {[:user], :type?, [:map, nil]}}]} =
                contract.conform(%{user: nil})
@@ -121,7 +121,7 @@ defmodule Drops.ContractTest do
       end
     end
 
-    test "returns deeply nested errors", %{contract: contract} do
+    test "returns success when valid", %{contract: contract} do
       assert {:ok, _} =
                contract.conform(%{
                  user: %{
@@ -134,7 +134,9 @@ defmodule Drops.ContractTest do
                    }
                  }
                })
+    end
 
+    test "returns deeply nested errors", %{contract: contract} do
       assert {:error, [{:error, {[:user, :address, :street], :filled?, [""]}}]} =
                contract.conform(%{
                  user: %{

--- a/test/contract/list_test.exs
+++ b/test/contract/list_test.exs
@@ -61,7 +61,7 @@ defmodule Drops.Contract.ListTest do
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, [{[:tags, 1, :name], :type?, [:string, 312]}]}]} =
+      assert {:error, [{:error, {[:tags, 1, :name], :type?, [:string, 312]}}]} =
                contract.conform(%{tags: [%{name: "red"}, %{name: 312}, %{name: "blue"}]})
     end
   end
@@ -86,7 +86,7 @@ defmodule Drops.Contract.ListTest do
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, [{[:tags, 1, :name], :type?, [:string, 312]}]}]} =
+      assert {:error, [{:error, {[:tags, 1, :name], :type?, [:string, 312]}}]} =
                contract.conform(%{
                  "tags" => [%{"name" => "red"}, %{"name" => 312}, %{"name" => "blue"}]
                })
@@ -139,7 +139,7 @@ defmodule Drops.Contract.ListTest do
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, [{[:tags, 1, 0, :name], :type?, [:string, 312]}]}]} =
+      assert {:error, [{:error, {[:tags, 1, 0, :name], :type?, [:string, 312]}}]} =
                contract.conform(%{
                  "tags" => [[%{"name" => "red"}], [%{"name" => 312}], [%{"name" => "blue"}]]
                })

--- a/test/contract/maybe_test.exs
+++ b/test/contract/maybe_test.exs
@@ -51,12 +51,15 @@ defmodule Drops.MaybeTest do
   describe "maybe/1 with :map when atomized" do
     contract do
       schema(atomize: true) do
-        %{required(:test) => maybe(:map)}
+        %{
+          required(:test) => maybe(:map),
+          optional(:user) => %{required(:name) => type(:string)}
+        }
       end
     end
 
     test "returns success with nil", %{contract: contract} do
-      assert {:ok, _} = contract.conform(%{"test" => nil})
+      assert {:ok, _} = contract.conform(%{"test" => nil, "user" => %{"name" => "John"}})
     end
 
     test "returns success with a map value", %{contract: contract} do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,8 @@ defmodule Drops.ContractCase do
   using do
     quote do
       import Drops.ContractCase
+
+      alias Drops.Contract.Schema
     end
   end
 


### PR DESCRIPTION
Introduce `Drops.Type` with:

- `Drops.Type` - primitive types list `:string`, `:integer` etc.
- `Drops.Type.Sum` - composition of two types
- `Drops.Type.List` - a `:list` type with a `member_type`
- `Drops.Type.Schema` - previous `Schema` module converted into a standard built-in type

Now a schema looks like this:

```elixir
contract.schema() #=> %Drops.Type.Schema{
  primitive: :map,
  constraints: [predicate: {:type?, :map}],
  keys: [
    %Drops.Type.Schema.Key{
      path: [:age],
      presence: :required,
      type: %Drops.Type{
        primitive: :integer,
        constraints: [predicate: {:type?, :integer}]
      }
    },
    %Drops.Type.Schema.Key{
      path: [:name],
      presence: :required,
      type: %Drops.Type{
        primitive: :string,
        constraints: [predicate: {:type?, :string}]
      }
    }
  ],
  atomize: false
}
```