### PR TITLE
Message backend with user-friendly errors

### DIFF
--- a/examples/contract/errors-01.exs
+++ b/examples/contract/errors-01.exs
@@ -1,0 +1,14 @@
+defmodule UserContract do
+  use Drops.Contract
+
+  schema do
+    %{
+      required(:name) => string(:filled?),
+      required(:email) => string(:filled?)
+    }
+  end
+end
+
+errors = UserContract.conform(%{name: "", email: 312}) |> UserContract.errors()
+
+Enum.map(errors, &to_string/1)

--- a/examples/contract/messages-01.exs
+++ b/examples/contract/messages-01.exs
@@ -1,0 +1,22 @@
+defmodule MyBackend do
+  use Drops.Contract.Messages.Backend
+
+  def text(:type?, type, input) do
+    "#{inspect(input)} received but it must be a #{type}"
+  end
+
+  def text(:filled?, _input) do
+    "cannot be empty"
+  end
+end
+defmodule UserContract do
+  use Drops.Contract, message_backend: MyBackend
+
+  schema do
+    %{
+      required(:name) => string(:filled?),
+      required(:email) => string(:filled?)
+    }
+  end
+end
+UserContract.conform(%{name: "", email: 312}) |> UserContract.errors()

--- a/examples/contract/rule-01.exs
+++ b/examples/contract/rule-01.exs
@@ -18,5 +18,15 @@ defmodule UserContract do
 end
 
 UserContract.conform(%{email: "jane@doe.org", login: nil})
+
 UserContract.conform(%{email: nil, login: "jane"})
+
 UserContract.conform(%{email: nil, login: nil})
+# {:error,
+#  [
+#    %Drops.Contract.Messages.Error.Rule{
+#      path: [],
+#      text: "email or login must be present",
+#      meta: %{}
+#    }
+#  ]}

--- a/examples/readme/contracts-01.ex
+++ b/examples/readme/contracts-01.ex
@@ -10,10 +10,5 @@ defmodule UserContract do
 end
 
 UserContract.conform(%{name: "Jane", email: "jane@doe.org"})
-# {:ok, %{name: "Jane", email: "jane@doe.org"}}
-
 UserContract.conform(%{email: 312})
-# {:error, [error: {[], :has_key?, [:name]}]}
-
 UserContract.conform(%{name: "Jane", email: 312})
-# {:error, [error: {[:email], :type?, [:string, 312]}]}

--- a/examples/readme/schemas-03.ex
+++ b/examples/readme/schemas-03.ex
@@ -13,7 +13,21 @@ UserContract.conform(%{name: "Jane", age: 21})
 # {:ok, %{name: "Jane", age: 21}}
 
 UserContract.conform(%{name: "", age: 21})
-# {:error, [error: {[:name], :filled?, [""]}]}
+# {:error,
+#  [
+#    %Drops.Contract.Messages.Error.Type{
+#      path: [:name],
+#      text: "must be filled",
+#      meta: %{args: [""], predicate: :filled?}
+#    }
+#  ]}
 
 UserContract.conform(%{name: "Jane", age: 12})
-# {:error, [error: {[:age], :gt?, [18, 12]}]}
+# {:error,
+#  [
+#    %Drops.Contract.Messages.Error.Type{
+#      path: [:age],
+#      text: "must be greater than 18",
+#      meta: %{args: [18, 12], predicate: :gt?}
+#    }
+#  ]}

--- a/examples/readme/schemas-04.ex
+++ b/examples/readme/schemas-04.ex
@@ -66,6 +66,14 @@ UserContract.conform(%{
 })
 # {:error,
 #  [
-#    error: {[:user, :address, :zipcode], :filled?, [""]},
-#    error: {[:user, :tags, 1, :created_at], :type?, [:integer, nil]}
+#    %Drops.Contract.Messages.Error.Type{
+#      path: [:user, :address, :zipcode],
+#      text: "must be filled",
+#      meta: %{args: [""], predicate: :filled?}
+#    },
+#    %Drops.Contract.Messages.Error.Type{
+#      path: [:user, :tags, 1, :created_at],
+#      text: "must be an integer",
+#      meta: %{args: [:integer, nil], predicate: :type?}
+#    }
 #  ]}

--- a/examples/readme/schemas-05.ex
+++ b/examples/readme/schemas-05.ex
@@ -11,5 +11,23 @@ end
 UserContract.conform(%{count: "1"})
 # {:ok, %{count: 1}}
 
+UserContract.conform(%{count: nil})
+#  [
+#    %Drops.Contract.Messages.Error.Caster{
+#      error: %Drops.Contract.Messages.Error.Type{
+#        path: [:count],
+#        text: "must be a string",
+#        meta: %{args: [:string, nil], predicate: :type?}
+#      }
+#    }
+#  ]}
+
 UserContract.conform(%{count: "-1"})
-# {:error, [error: {[:count], :gt?, [0, -1]}]}
+# {:error,
+#  [
+#    %Drops.Contract.Messages.Error.Type{
+#      path: [:count],
+#      text: "must be greater than 0",
+#      meta: %{args: [0, -1], predicate: :gt?}
+#    }
+#  ]}

--- a/lib/drops/contract/messages/backend.ex
+++ b/lib/drops/contract/messages/backend.ex
@@ -74,6 +74,10 @@ defmodule Drops.Contract.Messages.Backend do
           }
         }
       end
+
+      defp error({:or, {left, right}}) do
+        %Error.Sum{left: error(left), right: error(right)}
+      end
     end
   end
 end

--- a/lib/drops/contract/messages/backend.ex
+++ b/lib/drops/contract/messages/backend.ex
@@ -60,11 +60,11 @@ defmodule Drops.Contract.Messages.Backend do
       end
 
       defp error(text) when is_binary(text) do
-        %Error.Type{path: [], text: text, meta: %{}}
+        %Error.Rule{text: text}
       end
 
       defp error({path, text}) when is_list(path) do
-        %Error.Type{path: path, text: text, meta: %{}}
+        %Error.Rule{text: text, path: path}
       end
 
       defp error(%{path: path} = error), do: error

--- a/lib/drops/contract/messages/backend.ex
+++ b/lib/drops/contract/messages/backend.ex
@@ -1,0 +1,79 @@
+defmodule Drops.Contract.Messages.Backend do
+  @moduledoc ~S"""
+  Messages Backends are used to generate error messages from error results.
+
+  ## Examples
+
+      iex> defmodule MyBackend do
+      ...>   use Drops.Contract.Messages.Backend
+      ...>
+      ...>   def text(:type?, type, input) do
+      ...>     "#{inspect(input)} received but it must be a #{type}"
+      ...>   end
+      ...>
+      ...>   def text(:filled?, _input) do
+      ...>     "cannot be empty"
+      ...>   end
+      ...> end
+      iex> defmodule UserContract do
+      ...>   use Drops.Contract, message_backend: MyBackend
+      ...>
+      ...>   schema do
+      ...>     %{
+      ...>       required(:name) => string(:filled?),
+      ...>       required(:email) => string(:filled?)
+      ...>     }
+      ...>   end
+      ...> end
+      iex> UserContract.conform(%{name: "", email: 312}) |> UserContract.errors()
+      [
+        %Drops.Contract.Messages.Error{
+          path: [:email],
+          text: "312 received but it must be a string",
+          meta: %{args: [:string, 312], predicate: :type?}
+        },
+        %Drops.Contract.Messages.Error{
+          path: [:name],
+          text: "cannot be empty",
+          meta: %{args: [""], predicate: :filled?}
+        }
+      ]
+
+  """
+  @callback text(atom(), any()) :: String.t()
+  @callback text(atom(), any(), any()) :: String.t()
+
+  defmacro __using__(_opts) do
+    quote do
+      @behaviour Drops.Contract.Messages.Backend
+
+      alias Drops.Contract.Messages.Error
+
+      def errors(results) do
+        Enum.map(results, &error/1)
+      end
+
+      defp error({:error, {path, predicate, [value, input] = args}}) do
+        %Error{
+          path: path,
+          text: text(predicate, value, input),
+          meta: %{
+            predicate: predicate,
+            args: args
+          }
+        }
+      end
+
+      defp error({:error, {path, predicate, [input] = args}}) do
+        %Error{
+          path: path,
+          text: text(predicate, input),
+          meta: %{
+            predicate: predicate,
+            args: args
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/drops/contract/messages/backend.ex
+++ b/lib/drops/contract/messages/backend.ex
@@ -53,6 +53,17 @@ defmodule Drops.Contract.Messages.Backend do
         Enum.map(results, &error/1)
       end
 
+      defp error({:error, {[], :has_key?, [value]}}) do
+        %Error{
+          path: List.flatten([value]),
+          text: text(:has_key?, value),
+          meta: %{
+            predicate: :has_key?,
+            args: [value]
+          }
+        }
+      end
+
       defp error({:error, {path, predicate, [value, input] = args}}) do
         %Error{
           path: path,

--- a/lib/drops/contract/messages/default_backend.ex
+++ b/lib/drops/contract/messages/default_backend.ex
@@ -16,6 +16,7 @@ defmodule Drops.Contract.Messages.DefaultBackend do
       date_time: "must be a date time",
       time: "must be a time"
     },
+    has_key?: "is missing",
     filled?: "must be filled",
     empty?: "must be empty",
     eql?: "must be equal to %input%",

--- a/lib/drops/contract/messages/default_backend.ex
+++ b/lib/drops/contract/messages/default_backend.ex
@@ -16,7 +16,7 @@ defmodule Drops.Contract.Messages.DefaultBackend do
       date_time: "must be a date time",
       time: "must be a time"
     },
-    has_key?: "is missing",
+    has_key?: "key must be present",
     filled?: "must be filled",
     empty?: "must be empty",
     eql?: "must be equal to %input%",
@@ -30,10 +30,11 @@ defmodule Drops.Contract.Messages.DefaultBackend do
     size?: "size must be %input%",
     even?: "must be even",
     odd?: "must be odd",
-    match?: "must match %input%",
+    match?: "must have a valid format",
     includes?: "must include %input%",
     excludes?: "must exclude %input%",
-    in?: "must be one of: %input%"
+    in?: "must be one of: %input%",
+    not_in?: "must not be one of: %input%"
   }
 
   @impl true
@@ -47,8 +48,18 @@ defmodule Drops.Contract.Messages.DefaultBackend do
   end
 
   @impl true
+  def text(:match?, _regex, _input) do
+    @text_mapping[:match?]
+  end
+
+  @impl true
   def text(:in?, values, _input) do
     String.replace(@text_mapping[:in?], "%input%", Enum.join(values, ", "))
+  end
+
+  @impl true
+  def text(:not_in?, values, _input) do
+    String.replace(@text_mapping[:not_in?], "%input%", Enum.join(values, ", "))
   end
 
   @impl true

--- a/lib/drops/contract/messages/default_backend.ex
+++ b/lib/drops/contract/messages/default_backend.ex
@@ -4,6 +4,7 @@ defmodule Drops.Contract.Messages.DefaultBackend do
 
   @text_mapping %{
     type?: %{
+      nil: "must be nil",
       integer: "must be an integer",
       float: "must be a float",
       boolean: "must be boolean",

--- a/lib/drops/contract/messages/default_backend.ex
+++ b/lib/drops/contract/messages/default_backend.ex
@@ -1,0 +1,56 @@
+defmodule Drops.Contract.Messages.DefaultBackend do
+  @moduledoc false
+  use Drops.Contract.Messages.Backend
+
+  @text_mapping %{
+    type?: %{
+      integer: "must be an integer",
+      float: "must be a float",
+      boolean: "must be boolean",
+      list: "must be a list",
+      map: "must be a map",
+      string: "must be a string",
+      atom: "must be an atom",
+      date: "must be a date",
+      date_time: "must be a date time",
+      time: "must be a time"
+    },
+    filled?: "must be filled",
+    empty?: "must be empty",
+    eql?: "must be equal to %input%",
+    not_eql?: "must not be equal to %input%",
+    lt?: "must be less than %input%",
+    gt?: "must be greater than %input%",
+    lteq?: "must be less than or equal to %input%",
+    gteq?: "must be greater than or equal to %input%",
+    min_size?: "size cannot be less than %input%",
+    max_size?: "size cannot be greater than %input%",
+    size?: "size must be %input%",
+    even?: "must be even",
+    odd?: "must be odd",
+    match?: "must match %input%",
+    includes?: "must include %input%",
+    excludes?: "must exclude %input%",
+    in?: "must be one of: %input%"
+  }
+
+  @impl true
+  def text(predicate, _input) do
+    @text_mapping[predicate]
+  end
+
+  @impl true
+  def text(:type?, type, _input) do
+    @text_mapping[:type?][type]
+  end
+
+  @impl true
+  def text(:in?, values, _input) do
+    String.replace(@text_mapping[:in?], "%input%", Enum.join(values, ", "))
+  end
+
+  @impl true
+  def text(predicate, value, _input) do
+    String.replace(@text_mapping[predicate], "%input%", to_string(value))
+  end
+end

--- a/lib/drops/contract/messages/error.ex
+++ b/lib/drops/contract/messages/error.ex
@@ -11,4 +11,18 @@ defmodule Drops.Contract.Messages.Error do
       "#{Enum.join(path, ".")} #{text}"
     end
   end
+
+  defmodule Sum do
+    alias __MODULE__
+
+    @type t :: %__MODULE__{}
+
+    defstruct [:left, :right]
+
+    defimpl String.Chars, for: Sum do
+      def to_string(%Error.Sum{left: left, right: right}) do
+        "#{left} or #{right}"
+      end
+    end
+  end
 end

--- a/lib/drops/contract/messages/error.ex
+++ b/lib/drops/contract/messages/error.ex
@@ -25,4 +25,32 @@ defmodule Drops.Contract.Messages.Error do
       end
     end
   end
+
+  defmodule Set do
+    alias __MODULE__
+
+    @type t :: %__MODULE__{}
+
+    defstruct [:errors]
+
+    defimpl String.Chars, for: Set do
+      def to_string(%Error.Set{errors: errors}) do
+        Enum.map(errors, &Kernel.to_string/1) |> Enum.join(" and ")
+      end
+    end
+  end
+
+  defmodule Caster do
+    alias __MODULE__
+
+    @type t :: %__MODULE__{}
+
+    defstruct [:error]
+
+    defimpl String.Chars, for: Caster do
+      def to_string(%Error.Caster{error: error}) do
+        "cast error: #{Kernel.to_string(error)}"
+      end
+    end
+  end
 end

--- a/lib/drops/contract/messages/error.ex
+++ b/lib/drops/contract/messages/error.ex
@@ -1,0 +1,14 @@
+defmodule Drops.Contract.Messages.Error do
+  @moduledoc false
+  alias __MODULE__
+
+  @type t :: %__MODULE__{}
+
+  defstruct [:path, :text, :meta]
+
+  defimpl String.Chars, for: Error do
+    def to_string(%Error{path: path, text: text}) do
+      "#{Enum.join(path, ".")} #{text}"
+    end
+  end
+end

--- a/lib/drops/contract/messages/error.ex
+++ b/lib/drops/contract/messages/error.ex
@@ -18,7 +18,7 @@ defmodule Drops.Contract.Messages.Error do
 
     defimpl String.Chars, for: Error.Type do
       def to_string(%Error.Type{path: path, text: text}) do
-        String.trim("#{Enum.join(path, ".")} #{text}")
+        "#{Enum.join(path, ".")} #{text}"
       end
     end
 
@@ -42,7 +42,10 @@ defmodule Drops.Contract.Messages.Error do
 
     defimpl Error.Conversions, for: Sum do
       def nest(%Error.Sum{left: left, right: right} = error, root) do
-        Map.merge(error, %{left: Error.Conversions.nest(left, root), right: Error.Conversions.nest(right, root)})
+        Map.merge(error, %{
+          left: Error.Conversions.nest(left, root),
+          right: Error.Conversions.nest(right, root)
+        })
       end
     end
   end
@@ -79,6 +82,28 @@ defmodule Drops.Contract.Messages.Error do
     defimpl Error.Conversions, for: Error.Caster do
       def nest(%Error.Caster{error: error} = caster_error, root) do
         Map.merge(caster_error, %{error: Error.Conversions.nest(error, root)})
+      end
+    end
+  end
+
+  defmodule Rule do
+    @type t :: %__MODULE__{}
+
+    defstruct [:text, path: []]
+
+    defimpl String.Chars, for: Error.Rule do
+      def to_string(%Error.Rule{text: text, path: path}) when length(path) == 0 do
+        text
+      end
+
+      def to_string(%Error.Rule{text: text, path: path}) do
+        "#{Enum.join(path, ".")} #{text}"
+      end
+    end
+
+    defimpl Error.Conversions, for: Error.Caster do
+      def nest(%Error.Rule{path: path} = error, root) do
+        Map.merge(error, %{path: root ++ path})
       end
     end
   end

--- a/lib/drops/contract/messages/error.ex
+++ b/lib/drops/contract/messages/error.ex
@@ -1,20 +1,35 @@
 defmodule Drops.Contract.Messages.Error do
-  @moduledoc false
   alias __MODULE__
 
-  @type t :: %__MODULE__{}
+  defprotocol Conversions do
+    @doc """
+    Protocol for error conversions
+    """
 
-  defstruct [:path, :text, :meta]
+    @spec nest(error :: map(), root :: list()) :: map()
+    def nest(error, root)
+  end
 
-  defimpl String.Chars, for: Error do
-    def to_string(%Error{path: path, text: text}) do
-      "#{Enum.join(path, ".")} #{text}"
+  defmodule Type do
+    @moduledoc false
+    @type t :: %__MODULE__{}
+
+    defstruct [:path, :text, :meta]
+
+    defimpl String.Chars, for: Error.Type do
+      def to_string(%Error.Type{path: path, text: text}) do
+        String.trim("#{Enum.join(path, ".")} #{text}")
+      end
+    end
+
+    defimpl Error.Conversions, for: Error.Type do
+      def nest(%Error.Type{path: path} = error, root) do
+        Map.merge(error, %{path: root ++ path})
+      end
     end
   end
 
   defmodule Sum do
-    alias __MODULE__
-
     @type t :: %__MODULE__{}
 
     defstruct [:left, :right]
@@ -24,32 +39,46 @@ defmodule Drops.Contract.Messages.Error do
         "#{left} or #{right}"
       end
     end
+
+    defimpl Error.Conversions, for: Sum do
+      def nest(%Error.Sum{left: left, right: right} = error, root) do
+        Map.merge(error, %{left: Error.Conversions.nest(left, root), right: Error.Conversions.nest(right, root)})
+      end
+    end
   end
 
   defmodule Set do
-    alias __MODULE__
-
     @type t :: %__MODULE__{}
 
     defstruct [:errors]
 
-    defimpl String.Chars, for: Set do
+    defimpl String.Chars, for: Error.Set do
       def to_string(%Error.Set{errors: errors}) do
         Enum.map(errors, &Kernel.to_string/1) |> Enum.join(" and ")
+      end
+    end
+
+    defimpl Error.Conversions, for: Error.Set do
+      def nest(%Error.Set{errors: errors} = error, root) do
+        Map.merge(error, %{errors: Enum.map(errors, &Error.Conversions.nest(&1, root))})
       end
     end
   end
 
   defmodule Caster do
-    alias __MODULE__
-
     @type t :: %__MODULE__{}
 
     defstruct [:error]
 
-    defimpl String.Chars, for: Caster do
+    defimpl String.Chars, for: Error.Caster do
       def to_string(%Error.Caster{error: error}) do
         "cast error: #{Kernel.to_string(error)}"
+      end
+    end
+
+    defimpl Error.Conversions, for: Error.Caster do
+      def nest(%Error.Caster{error: error} = caster_error, root) do
+        Map.merge(caster_error, %{error: Error.Conversions.nest(error, root)})
       end
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -48,6 +48,7 @@ defmodule Drops.MixProject do
       groups_for_modules: [
         Validation: [
           Drops.Contract,
+          Drops.Contract.Messages,
           Drops.Casters,
           Drops.Predicates,
           Drops.Validator

--- a/test/contract/casters_test.exs
+++ b/test/contract/casters_test.exs
@@ -27,13 +27,14 @@ defmodule Drops.CastersTest do
     end
 
     test "returns error result when output is invalid", %{contract: contract} do
-      assert {:error, [error: {[:test], :size?, [3, "12"]}]} =
-               contract.conform(%{test: 12})
+      assert_errors(["test size must be 3"], contract.conform(%{test: 12}))
     end
 
     test "returns error when casting could not be applied", %{contract: contract} do
-      assert {:error, [{:cast, {:error, {[:test], :type?, [:integer, "12"]}}}]} =
-               contract.conform(%{test: "12"})
+      assert_errors(
+        ["cast error: test must be an integer"],
+        contract.conform(%{test: "12"})
+      )
     end
   end
 

--- a/test/contract/list_test.exs
+++ b/test/contract/list_test.exs
@@ -16,8 +16,10 @@ defmodule Drops.Contract.ListTest do
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, {[:tags, 1], :type?, [:string, 312]}}]} =
-               contract.conform(%{tags: ["red", 312, "blue"]})
+      assert_errors(
+        ["tags.1 must be a string"],
+        contract.conform(%{tags: ["red", 312, "blue"]})
+      )
     end
   end
 
@@ -36,8 +38,10 @@ defmodule Drops.Contract.ListTest do
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, {[:tags, 1], :filled?, [""]}}]} =
-               contract.conform(%{tags: ["red", "", "blue"]})
+      assert_errors(
+        ["tags.1 must be filled"],
+        contract.conform(%{tags: ["red", "", "blue"]})
+      )
     end
   end
 
@@ -61,8 +65,10 @@ defmodule Drops.Contract.ListTest do
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, {[:tags, 1, :name], :type?, [:string, 312]}}]} =
-               contract.conform(%{tags: [%{name: "red"}, %{name: 312}, %{name: "blue"}]})
+      assert_errors(
+        ["tags.1.name must be a string"],
+        contract.conform(%{tags: [%{name: "red"}, %{name: 312}, %{name: "blue"}]})
+      )
     end
   end
 
@@ -86,10 +92,12 @@ defmodule Drops.Contract.ListTest do
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, {[:tags, 1, :name], :type?, [:string, 312]}}]} =
-               contract.conform(%{
-                 "tags" => [%{"name" => "red"}, %{"name" => 312}, %{"name" => "blue"}]
-               })
+      assert_errors(
+        ["tags.1.name must be a string"],
+        contract.conform(%{
+          "tags" => [%{"name" => "red"}, %{"name" => 312}, %{"name" => "blue"}]
+        })
+      )
     end
   end
 
@@ -108,8 +116,10 @@ defmodule Drops.Contract.ListTest do
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, {[:tags, 1, 0], :type?, [:string, 312]}}]} =
-               contract.conform(%{"tags" => [["red"], [312], ["blue"]]})
+      assert_errors(
+        ["tags.1.0 must be a string"],
+        contract.conform(%{"tags" => [["red"], [312], ["blue"]]})
+      )
     end
   end
 
@@ -128,21 +138,29 @@ defmodule Drops.Contract.ListTest do
     end
 
     test "returns success with valid data", %{contract: contract} do
-      assert {:ok, %{tags: [[%{name: "red"}], [%{name: "green"}], [%{name: "blue"}]]}} =
-               contract.conform(%{
-                 "tags" => [
-                   [%{"name" => "red"}],
-                   [%{"name" => "green"}],
-                   [%{"name" => "blue"}]
-                 ]
-               })
+      assert_errors(
+        ["tags.1.0.name must be a string"],
+        contract.conform(%{
+          "tags" => [
+            [%{"name" => "red"}],
+            [%{"name" => 312}],
+            [%{"name" => "blue"}]
+          ]
+        })
+      )
     end
 
     test "defining required keys with types", %{contract: contract} do
-      assert {:error, [{:error, {[:tags, 1, 0, :name], :type?, [:string, 312]}}]} =
-               contract.conform(%{
-                 "tags" => [[%{"name" => "red"}], [%{"name" => 312}], [%{"name" => "blue"}]]
-               })
+      assert_errors(
+        ["tags.1.0.name must be a string"],
+        contract.conform(%{
+          "tags" => [
+            [%{"name" => "red"}],
+            [%{"name" => 312}],
+            [%{"name" => "blue"}]
+          ]
+        })
+      )
     end
   end
 end

--- a/test/contract/maybe_test.exs
+++ b/test/contract/maybe_test.exs
@@ -17,13 +17,10 @@ defmodule Drops.MaybeTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :type?, [nil, 312]}},
-                   {:error, {[:test], :type?, [:string, 312]}}}
-              ]} =
-               contract.conform(%{test: 312})
+      assert_errors(
+        ["test must be nil or test must be a string"],
+        contract.conform(%{test: 312})
+      )
     end
   end
 
@@ -43,23 +40,17 @@ defmodule Drops.MaybeTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :type?, [nil, 312]}},
-                   {:error, {[:test], :type?, [:string, 312]}}}
-              ]} =
-               contract.conform(%{test: 312})
+      assert_errors(
+        ["test must be nil or test must be a string"],
+        contract.conform(%{test: 312})
+      )
     end
 
     test "returns error when extra predicates fail", %{contract: contract} do
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :type?, [nil, ""]}},
-                   {:error, {[:test], :filled?, [""]}}}
-              ]} =
-               contract.conform(%{test: ""})
+      assert_errors(
+        ["test must be nil or test must be filled"],
+        contract.conform(%{test: ""})
+      )
     end
   end
 
@@ -82,13 +73,10 @@ defmodule Drops.MaybeTest do
     end
 
     test "returns error with a non-map value", %{contract: contract} do
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :type?, [nil, 312]}},
-                   {:error, {[:test], :type?, [:map, 312]}}}
-              ]} =
-               contract.conform(%{"test" => 312})
+      assert_errors(
+        ["test must be nil or test must be a map"],
+        contract.conform(%{"test" => 312})
+      )
     end
   end
 
@@ -108,13 +96,10 @@ defmodule Drops.MaybeTest do
     end
 
     test "returns error with a non-map value", %{contract: contract} do
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :type?, [nil, 312]}},
-                   {:error, {[:test], :type?, [:map, 312]}}}
-              ]} =
-               contract.conform(%{test: 312})
+      assert_errors(
+        ["test must be nil or test must be a map"],
+        contract.conform(%{test: 312})
+      )
     end
   end
 
@@ -139,13 +124,10 @@ defmodule Drops.MaybeTest do
     end
 
     test "returns error with a non-map value", %{contract: contract} do
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :type?, [nil, 312]}},
-                   {:error, {[:test], :type?, [:map, 312]}}}
-              ]} =
-               contract.conform(%{test: 312})
+      assert_errors(
+        ["test must be nil or test.name must be a string"],
+        contract.conform(%{test: %{name: 312}})
+      )
     end
   end
 end

--- a/test/contract/messages_test.exs
+++ b/test/contract/messages_test.exs
@@ -14,9 +14,8 @@ defmodule Drops.Contract.MessagesTest do
     end
 
     test "returns errors from the has_key? predicate", %{contract: contract} do
-      result = contract.conform(%{name: "Jane Doe"})
-
-      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+      assert {:error, [error = %{path: path, meta: meta}]} =
+               contract.conform(%{name: "Jane Doe"})
 
       assert path == [:age]
       assert meta == %{predicate: :has_key?, args: [:age]}
@@ -37,9 +36,8 @@ defmodule Drops.Contract.MessagesTest do
     end
 
     test "returns errors from a type? predicate", %{contract: contract} do
-      result = contract.conform(%{name: "Jane Doe", age: "twenty"})
-
-      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+      assert {:error, [error = %{path: path, meta: meta}]} =
+               contract.conform(%{name: "Jane Doe", age: "twenty"})
 
       assert path == [:age]
       assert meta == %{predicate: :type?, args: [:integer, "twenty"]}
@@ -47,9 +45,8 @@ defmodule Drops.Contract.MessagesTest do
     end
 
     test "returns errors from a predicate with no args", %{contract: contract} do
-      result = contract.conform(%{name: "", age: 21})
-
-      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+      assert {:error, [error = %{path: path, meta: meta}]} =
+               contract.conform(%{name: "", age: 21})
 
       assert path == [:name]
       assert meta == %{predicate: :filled?, args: [""]}
@@ -57,9 +54,8 @@ defmodule Drops.Contract.MessagesTest do
     end
 
     test "returns errors from a predicate with args", %{contract: contract} do
-      result = contract.conform(%{name: "Jane", age: 12})
-
-      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+      assert {:error, [error = %{path: path, meta: meta}]} =
+               contract.conform(%{name: "Jane", age: 12})
 
       assert path == [:age]
       assert meta == %{predicate: :gt?, args: [18, 12]}
@@ -67,9 +63,8 @@ defmodule Drops.Contract.MessagesTest do
     end
 
     test "returns errors from in? with a list of valid values", %{contract: contract} do
-      result = contract.conform(%{name: "Jane", age: 19, role: "oops"})
-
-      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+      assert {:error, [error = %{path: path, meta: meta}]} =
+               contract.conform(%{name: "Jane", age: 19, role: "oops"})
 
       assert path == [:role]
       assert meta == %{predicate: :in?, args: [["admin", "user"], "oops"]}
@@ -77,9 +72,8 @@ defmodule Drops.Contract.MessagesTest do
     end
 
     test "returns errors from a sum type", %{contract: contract} do
-      result = contract.conform(%{birthday: "oops"})
-
-      assert [error = %{left: left_error, right: right_error}] = contract.errors(result)
+      assert {:error, [error = %{left: left_error, right: right_error}]} =
+               contract.conform(%{birthday: "oops"})
 
       assert left_error.path == [:birthday]
       assert left_error.meta == %{predicate: :type?, args: [nil, "oops"]}
@@ -105,9 +99,8 @@ defmodule Drops.Contract.MessagesTest do
     end
 
     test "returns errors from a type? predicate", %{contract: contract} do
-      result = contract.conform(%{user: %{age: "twenty"}})
-
-      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+      assert {:error, [error = %{path: path, meta: meta}]} =
+               contract.conform(%{user: %{age: "twenty"}})
 
       assert path == [:user, :age]
       assert meta == %{predicate: :type?, args: [:integer, "twenty"]}
@@ -115,9 +108,8 @@ defmodule Drops.Contract.MessagesTest do
     end
 
     test "returns errors from a list type", %{contract: contract} do
-      result = contract.conform(%{user: %{roles: ["admin", 312, "moderator"]}})
-
-      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+      assert {:error, [error = %{path: path, meta: meta}]} =
+               contract.conform(%{user: %{roles: ["admin", 312, "moderator"]}})
 
       assert path == [:user, :roles, 1]
       assert meta == %{predicate: :type?, args: [:string, 312]}

--- a/test/contract/messages_test.exs
+++ b/test/contract/messages_test.exs
@@ -3,6 +3,27 @@ defmodule Drops.Contract.MessagesTest do
 
   doctest Drops.Contract.Messages.Backend
 
+  describe "errors/1 with key errors" do
+    contract do
+      schema do
+        %{
+          required(:name) => string(:filled?),
+          required(:age) => integer(gt?: 18)
+        }
+      end
+    end
+
+    test "returns errors from the has_key? predicate", %{contract: contract} do
+      result = contract.conform(%{name: "Jane Doe"})
+
+      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+
+      assert path == [:age]
+      assert meta == %{predicate: :has_key?, args: [:age]}
+      assert to_string(error) == "age is missing"
+    end
+  end
+
   describe "errors/1" do
     contract do
       schema do

--- a/test/contract/messages_test.exs
+++ b/test/contract/messages_test.exs
@@ -20,7 +20,7 @@ defmodule Drops.Contract.MessagesTest do
 
       assert path == [:age]
       assert meta == %{predicate: :has_key?, args: [:age]}
-      assert to_string(error) == "age is missing"
+      assert to_string(error) == "age key must be present"
     end
   end
 

--- a/test/contract/messages_test.exs
+++ b/test/contract/messages_test.exs
@@ -1,0 +1,57 @@
+defmodule Drops.Contract.MessagesTest do
+  use Drops.ContractCase
+
+  doctest Drops.Contract.Messages.Backend
+
+  describe "errors/1" do
+    contract do
+      schema do
+        %{
+          required(:name) => string(:filled?),
+          required(:age) => integer(gt?: 18),
+          optional(:role) => string(in?: ["admin", "user"])
+        }
+      end
+    end
+
+    test "returns errors from a type? predicate", %{contract: contract} do
+      result = contract.conform(%{name: "Jane Doe", age: "twenty"})
+
+      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+
+      assert path == [:age]
+      assert meta == %{predicate: :type?, args: [:integer, "twenty"]}
+      assert to_string(error) == "age must be an integer"
+    end
+
+    test "returns errors from a predicate with no args", %{contract: contract} do
+      result = contract.conform(%{name: "", age: 21})
+
+      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+
+      assert path == [:name]
+      assert meta == %{predicate: :filled?, args: [""]}
+      assert to_string(error) == "name must be filled"
+    end
+
+    test "returns errors from a predicate with args", %{contract: contract} do
+      result = contract.conform(%{name: "Jane", age: 12})
+
+      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+
+      assert path == [:age]
+      assert meta == %{predicate: :gt?, args: [18, 12]}
+      assert to_string(error) == "age must be greater than 18"
+    end
+
+    test "returns errors from in? with a list of valid values", %{contract: contract} do
+      result = contract.conform(%{name: "Jane", age: 19, role: "oops"})
+
+      assert [error = %{path: path, meta: meta}] = contract.errors(result)
+
+      assert path == [:role]
+      assert meta == %{predicate: :in?, args: [["admin", "user"], "oops"]}
+      assert to_string(error) == "role must be one of: admin, user"
+    end
+  end
+end

--- a/test/contract/predicates_test.exs
+++ b/test/contract/predicates_test.exs
@@ -15,8 +15,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [nil, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be nil"], contract.conform(%{test: 312}))
     end
   end
 
@@ -32,8 +31,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:atom, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be an atom"], contract.conform(%{test: 312}))
     end
   end
 
@@ -49,8 +47,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:string, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a string"], contract.conform(%{test: 312}))
     end
   end
 
@@ -66,8 +63,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-integer value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:integer, "Hello"]}}]} =
-               contract.conform(%{test: "Hello"})
+      assert_errors(["test must be an integer"], contract.conform(%{test: "Hello"}))
     end
   end
 
@@ -83,8 +79,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-integer value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:float, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a float"], contract.conform(%{test: "Hello"}))
     end
   end
 
@@ -100,8 +95,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-map value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:map, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a map"], contract.conform(%{test: 312}))
     end
   end
 
@@ -117,8 +111,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:date, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a date"], contract.conform(%{test: 312}))
     end
   end
 
@@ -134,8 +127,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:date_time, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a date time"], contract.conform(%{test: 312}))
     end
   end
 
@@ -151,8 +143,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:time, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a time"], contract.conform(%{test: 312}))
     end
   end
 
@@ -168,8 +159,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:list, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a list"], contract.conform(%{test: 312}))
     end
   end
 
@@ -185,8 +175,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with an empty string", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :filled?, [""]}}]} =
-               contract.conform(%{test: ""})
+      assert_errors(["test must be filled"], contract.conform(%{test: ""}))
     end
   end
 
@@ -202,8 +191,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-empty string", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :empty?, ["Hello"]}}]} =
-               contract.conform(%{test: "Hello"})
+      assert_errors(["test must be empty"], contract.conform(%{test: "Hello"}))
     end
   end
 
@@ -219,8 +207,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-empty list", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :empty?, [[1, 2]]}}]} =
-               contract.conform(%{test: [1, 2]})
+      assert_errors(["test must be empty"], contract.conform(%{test: [1, 2]}))
     end
   end
 
@@ -236,8 +223,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error with a non-empty map", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :empty?, [%{a: 1}]}}]} =
-               contract.conform(%{test: %{a: 1}})
+      assert_errors(["test must be empty"], contract.conform(%{test: %{a: 1}}))
     end
   end
 
@@ -253,8 +239,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value is not equal", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :eql?, ["Hello", "World"]}}]} =
-               contract.conform(%{test: "World"})
+      assert_errors(["test must be equal to Hello"], contract.conform(%{test: "World"}))
     end
   end
 
@@ -270,8 +255,10 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value is equal", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :not_eql?, ["Hello", "Hello"]}}]} =
-               contract.conform(%{test: "Hello"})
+      assert_errors(
+        ["test must not be equal to Hello"],
+        contract.conform(%{test: "Hello"})
+      )
     end
   end
 
@@ -287,8 +274,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value is not even", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :even?, [11]}}]} =
-               contract.conform(%{test: 11})
+      assert_errors(["test must be even"], contract.conform(%{test: 11}))
     end
   end
 
@@ -304,8 +290,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value is not even", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :odd?, [12]}}]} =
-               contract.conform(%{test: 12})
+      assert_errors(["test must be odd"], contract.conform(%{test: 12}))
     end
   end
 
@@ -321,8 +306,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value is not greater than the arg", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :gt?, [1, 0]}}]} =
-               contract.conform(%{test: 0})
+      assert_errors(["test must be greater than 1"], contract.conform(%{test: 0}))
     end
   end
 
@@ -342,8 +326,10 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value less than the arg", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :gteq?, [1, 0]}}]} =
-               contract.conform(%{test: 0})
+      assert_errors(
+        ["test must be greater than or equal to 1"],
+        contract.conform(%{test: 0})
+      )
     end
   end
 
@@ -359,8 +345,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value is not even", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :lt?, [1, 2]}}]} =
-               contract.conform(%{test: 2})
+      assert_errors(["test must be less than 1"], contract.conform(%{test: 2}))
     end
   end
 
@@ -380,8 +365,10 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value greater than the arg", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :lteq?, [1, 2]}}]} =
-               contract.conform(%{test: 2})
+      assert_errors(
+        ["test must be less than or equal to 1"],
+        contract.conform(%{test: 2})
+      )
     end
   end
 
@@ -401,8 +388,7 @@ defmodule Drops.PredicatesTest do
     test "returns error when the value's size is not equal to the arg", %{
       contract: contract
     } do
-      assert {:error, [{:error, {[:test], :size?, [2, [1]]}}]} =
-               contract.conform(%{test: [1]})
+      assert_errors(["test size must be 2"], contract.conform(%{test: [1]}))
     end
   end
 
@@ -423,8 +409,7 @@ defmodule Drops.PredicatesTest do
     test "returns error when the value's size is not equal to the arg", %{
       contract: contract
     } do
-      assert {:error, [{:error, {[:test], :size?, [2, %{a: 1}]}}]} =
-               contract.conform(%{test: %{a: 1}})
+      assert_errors(["test size must be 2"], contract.conform(%{test: %{a: 1}}))
     end
   end
 
@@ -444,8 +429,7 @@ defmodule Drops.PredicatesTest do
     test "returns error when the value's size is not equal to the arg", %{
       contract: contract
     } do
-      assert {:error, [{:error, {[:test], :size?, [2, "a"]}}]} =
-               contract.conform(%{test: "a"})
+      assert_errors(["test size must be 2"], contract.conform(%{test: "a"}))
     end
   end
 
@@ -471,8 +455,7 @@ defmodule Drops.PredicatesTest do
     test "returns error when the value's size is greater than the arg", %{
       contract: contract
     } do
-      assert {:error, [{:error, {[:test], :max_size?, [2, [1, 2, 3]]}}]} =
-               contract.conform(%{test: [1, 2, 3]})
+      assert_errors(["test size cannot be greater than 2"], contract.conform(%{test: [1, 2, 3]}))
     end
   end
 
@@ -498,8 +481,10 @@ defmodule Drops.PredicatesTest do
     test "returns error when the value's size is greater than the arg", %{
       contract: contract
     } do
-      assert {:error, [{:error, {[:test], :max_size?, [2, "abc"]}}]} =
-               contract.conform(%{test: "abc"})
+      assert_errors(
+        ["test size cannot be greater than 2"],
+        contract.conform(%{test: "abc"})
+      )
     end
   end
 
@@ -526,8 +511,10 @@ defmodule Drops.PredicatesTest do
     test "returns error when the value's size is greater than the arg", %{
       contract: contract
     } do
-      assert {:error, [{:error, {[:test], :max_size?, [2, %{a: 1, b: 2, c: 3}]}}]} =
-               contract.conform(%{test: %{a: 1, b: 2, c: 3}})
+      assert_errors(
+        ["test size cannot be greater than 2"],
+        contract.conform(%{test: %{a: 1, b: 2, c: 3}})
+      )
     end
   end
 
@@ -555,6 +542,8 @@ defmodule Drops.PredicatesTest do
     } do
       assert {:error, [{:error, {[:test], :min_size?, [2, [1]]}}]} =
                contract.conform(%{test: [1]})
+
+      assert_errors(["test size cannot be less than 2"], contract.conform(%{test: [1]}))
     end
   end
 
@@ -580,8 +569,7 @@ defmodule Drops.PredicatesTest do
     test "returns error when the value's size is less than the arg", %{
       contract: contract
     } do
-      assert {:error, [{:error, {[:test], :min_size?, [2, "a"]}}]} =
-               contract.conform(%{test: "a"})
+      assert_errors(["test size cannot be less than 2"], contract.conform(%{test: "a"}))
     end
   end
 
@@ -609,8 +597,10 @@ defmodule Drops.PredicatesTest do
     test "returns error when the value's size is less than the arg", %{
       contract: contract
     } do
-      assert {:error, [{:error, {[:test], :min_size?, [2, %{a: 1}]}}]} =
-               contract.conform(%{test: %{a: 1}})
+      assert_errors(
+        ["test size cannot be less than 2"],
+        contract.conform(%{test: %{a: 1}})
+      )
     end
   end
 
@@ -626,8 +616,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns success when the arg is not included in the list", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :includes?, [2, [1, 3]]}}]} =
-               contract.conform(%{test: [1, 3]})
+      assert_errors(["test must include 2"], contract.conform(%{test: [1, 3]}))
     end
   end
 
@@ -643,8 +632,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns success when the arg is included in the list", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :excludes?, [2, [1, 2]]}}]} =
-               contract.conform(%{test: [1, 2]})
+      assert_errors(["test must exclude 2"], contract.conform(%{test: [1, 2]}))
     end
   end
 
@@ -660,8 +648,7 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns success when the value doesn't match the regexp", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :match?, [~r/\d+/, "Hello"]}}]} =
-               contract.conform(%{test: "Hello"})
+      assert_errors(["test must have a valid format"], contract.conform(%{test: "Hello"}))
     end
   end
 
@@ -677,8 +664,10 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value is not in the list", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :in?, [["Hello", "World"], "312"]}}]} =
-               contract.conform(%{test: "312"})
+      assert_errors(
+        ["test must be one of: Hello, World"],
+        contract.conform(%{test: "312"})
+      )
     end
   end
 
@@ -694,8 +683,10 @@ defmodule Drops.PredicatesTest do
     end
 
     test "returns error when the value is in the list", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :not_in?, [["Hello", "World"], "Hello"]}}]} =
-               contract.conform(%{test: "Hello"})
+      assert_errors(
+        ["test must not be one of: Hello, World"],
+        contract.conform(%{test: "Hello"})
+      )
     end
   end
 end

--- a/test/contract/predicates_test.exs
+++ b/test/contract/predicates_test.exs
@@ -540,9 +540,6 @@ defmodule Drops.PredicatesTest do
     test "returns error when the value's size is less than the arg", %{
       contract: contract
     } do
-      assert {:error, [{:error, {[:test], :min_size?, [2, [1]]}}]} =
-               contract.conform(%{test: [1]})
-
       assert_errors(["test size cannot be less than 2"], contract.conform(%{test: [1]}))
     end
   end

--- a/test/contract/rule_test.exs
+++ b/test/contract/rule_test.exs
@@ -12,7 +12,7 @@ defmodule Drops.Contract.RuleTest do
 
       rule(:unique?, %{name: name}) do
         case name do
-          "John" -> {:error, {:taken, [:name], name}}
+          "John" -> {:error, {[:user, :name], :taken}}
           _ -> :ok
         end
       end
@@ -23,13 +23,11 @@ defmodule Drops.Contract.RuleTest do
     end
 
     test "returns predicate errors and skips rules", %{contract: contract} do
-      assert {:error, [{:error, {[:name], :filled?, [""]}}]} =
-               contract.conform(%{name: ""})
+      assert_errors(["name must be filled"], contract.conform(%{name: ""}))
     end
 
     test "returns rule errors", %{contract: contract} do
-      assert {:error, [{:error, {:taken, [:name], "John"}}]} =
-               contract.conform(%{name: "John"})
+      assert_errors(["user.name taken"], contract.conform(%{name: "John"}))
     end
   end
 
@@ -46,7 +44,7 @@ defmodule Drops.Contract.RuleTest do
 
       rule(:unique?, %{user: %{name: name}}) do
         case name do
-          "John" -> {:error, {:taken, [:user, :name], name}}
+          "John" -> {:error, {[:user, :name], :taken}}
           _ -> :ok
         end
       end
@@ -57,16 +55,12 @@ defmodule Drops.Contract.RuleTest do
     end
 
     test "returns predicate errors and skips rules", %{contract: contract} do
-      assert {:error, [{:error, {[:user], :type?, [:map, ""]}}]} =
-               contract.conform(%{user: ""})
-
-      assert {:error, [{:error, {[:user, :name], :filled?, [""]}}]} =
-               contract.conform(%{user: %{name: ""}})
+      assert_errors(["user must be a map"], contract.conform(%{user: ""}))
+      assert_errors(["user.name must be filled"], contract.conform(%{user: %{name: ""}}))
     end
 
     test "returns rule errors", %{contract: contract} do
-      assert {:error, [{:error, {:taken, [:user, :name], "John"}}]} =
-               contract.conform(%{user: %{name: "John"}})
+      assert_errors(["user.name taken"], contract.conform(%{user: %{name: "John"}}))
     end
   end
 
@@ -96,18 +90,17 @@ defmodule Drops.Contract.RuleTest do
     end
 
     test "returns predicate errors and skips rules", %{contract: contract} do
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:login], :type?, [nil, ""]}},
-                   {:error, {[:login], :filled?, [""]}}}
-              ]} =
-               contract.conform(%{login: "", email: nil})
+      assert_errors(
+        ["login must be nil or login must be filled"],
+        contract.conform(%{login: "", email: nil})
+      )
     end
 
     test "returns rule errors", %{contract: contract} do
-      assert {:error, ["either login or email required"]} =
-               contract.conform(%{login: nil, email: nil})
+      assert_errors(
+        ["either login or email required"],
+        contract.conform(%{login: nil, email: nil})
+      )
     end
   end
 end

--- a/test/contract/type_test.exs
+++ b/test/contract/type_test.exs
@@ -13,8 +13,7 @@ defmodule Drops.Contract.TypeTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:string, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a string"], contract.conform(%{test: 312}))
     end
   end
 
@@ -32,19 +31,10 @@ defmodule Drops.Contract.TypeTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error,
-              [
-                or: {
-                  {:error, {[:test], :type?, [nil, :invalid]}},
-                  {:error,
-                   [
-                     or:
-                       {{:error, {[:test], :type?, [:integer, :invalid]}},
-                        {:error, {[:test], :type?, [:string, :invalid]}}}
-                   ]}
-                }
-              ]} =
-               contract.conform(%{test: :invalid})
+      assert_errors(
+        ["test must be nil or test must be an integer or test must be a string"],
+        contract.conform(%{test: :invalid})
+      )
     end
   end
 
@@ -61,21 +51,15 @@ defmodule Drops.Contract.TypeTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :type?, [:integer, :invalid]}},
-                   {:error, {[:test], :type?, [:string, :invalid]}}}
-              ]} =
-               contract.conform(%{test: :invalid})
+      assert_errors(
+        ["test must be an integer or test must be a string"],
+        contract.conform(%{test: :invalid})
+      )
 
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :type?, [:integer, ""]}},
-                   {:error, {[:test], :filled?, [""]}}}
-              ]} =
-               contract.conform(%{test: ""})
+      assert_errors(
+        ["test must be an integer or test must be filled"],
+        contract.conform(%{test: ""})
+      )
     end
   end
 
@@ -92,21 +76,15 @@ defmodule Drops.Contract.TypeTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :filled?, [[]]}},
-                   {:error, {[:test], :type?, [:map, []]}}}
-              ]} =
-               contract.conform(%{test: []})
+      assert_errors(
+        ["test must be filled or test must be a map"],
+        contract.conform(%{test: []})
+      )
 
-      assert {:error,
-              [
-                or:
-                  {{:error, {[:test], :type?, [:list, %{}]}},
-                   {:error, {[:test], :filled?, [%{}]}}}
-              ]} =
-               contract.conform(%{test: %{}})
+      assert_errors(
+        ["test must be a list or test must be filled"],
+        contract.conform(%{test: %{}})
+      )
     end
   end
 end

--- a/test/contract/types/boolean_test.exs
+++ b/test/contract/types/boolean_test.exs
@@ -14,8 +14,7 @@ defmodule Drops.Contract.Types.BooleanTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:boolean, :invalid]}}]} =
-               contract.conform(%{test: :invalid})
+      assert_errors(["test must be boolean"], contract.conform(%{test: :invalid}))
     end
   end
 end

--- a/test/contract/types/float_test.exs
+++ b/test/contract/types/float_test.exs
@@ -13,8 +13,7 @@ defmodule Drops.Contract.Types.FloatTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:float, :invalid]}}]} =
-               contract.conform(%{test: :invalid})
+      assert_errors(["test must be a float"], contract.conform(%{test: "hello"}))
     end
   end
 
@@ -30,31 +29,8 @@ defmodule Drops.Contract.Types.FloatTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:float, :invalid]}}]} =
-               contract.conform(%{test: :invalid})
-
-      assert {:error, [{:error, {[:test], :gt?, [10, 3.2]}}]} =
-               contract.conform(%{test: 3.2})
-    end
-  end
-
-  describe "float/1 with an extra predicate with args" do
-    contract do
-      schema do
-        %{required(:test) => float(gt?: 2)}
-      end
-    end
-
-    test "returns success with valid data", %{contract: contract} do
-      assert {:ok, %{test: 31.2}} = contract.conform(%{test: 31.2})
-    end
-
-    test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:float, :invalid]}}]} =
-               contract.conform(%{test: :invalid})
-
-      assert {:error, [{:error, {[:test], :gt?, [2, 0.0]}}]} =
-               contract.conform(%{test: 0.0})
+      assert_errors(["test must be a float"], contract.conform(%{test: :invalid}))
+      assert_errors(["test must be greater than 10"], contract.conform(%{test: 3.2}))
     end
   end
 
@@ -70,14 +46,9 @@ defmodule Drops.Contract.Types.FloatTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:float, :invalid]}}]} =
-               contract.conform(%{test: :invalid})
-
-      assert {:error, [{:error, {[:test], :lt?, [100, 200.0]}}]} =
-               contract.conform(%{test: 200.0})
-
-      assert {:error, [{:error, {[:test], :gt?, [0, 0.0]}}]} =
-               contract.conform(%{test: 0.0})
+      assert_errors(["test must be a float"], contract.conform(%{test: :invalid}))
+      assert_errors(["test must be less than 100"], contract.conform(%{test: 200.0}))
+      assert_errors(["test must be greater than 0"], contract.conform(%{test: 0.0}))
     end
   end
 end

--- a/test/contract/types/integer_test.exs
+++ b/test/contract/types/integer_test.exs
@@ -13,8 +13,7 @@ defmodule Drops.Contract.Types.IntegerTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:integer, :invalid]}}]} =
-               contract.conform(%{test: :invalid})
+      assert_errors(["test must be an integer"], contract.conform(%{test: :invalid}))
     end
   end
 
@@ -30,11 +29,8 @@ defmodule Drops.Contract.Types.IntegerTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:integer, :invalid]}}]} =
-               contract.conform(%{test: :invalid})
-
-      assert {:error, [{:error, {[:test], :odd?, [312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be an integer"], contract.conform(%{test: :invalid}))
+      assert_errors(["test must be odd"], contract.conform(%{test: 312}))
     end
   end
 
@@ -50,11 +46,8 @@ defmodule Drops.Contract.Types.IntegerTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:integer, :invalid]}}]} =
-               contract.conform(%{test: :invalid})
-
-      assert {:error, [{:error, {[:test], :gt?, [2, 0]}}]} =
-               contract.conform(%{test: 0})
+      assert_errors(["test must be an integer"], contract.conform(%{test: :invalid}))
+      assert_errors(["test must be greater than 2"], contract.conform(%{test: 0}))
     end
   end
 
@@ -70,14 +63,9 @@ defmodule Drops.Contract.Types.IntegerTest do
     end
 
     test "returns error with invalid data", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:integer, :invalid]}}]} =
-               contract.conform(%{test: :invalid})
-
-      assert {:error, [{:error, {[:test], :even?, [7]}}]} =
-               contract.conform(%{test: 7})
-
-      assert {:error, [{:error, {[:test], :gt?, [2, 0]}}]} =
-               contract.conform(%{test: 0})
+      assert_errors(["test must be an integer"], contract.conform(%{test: :invalid}))
+      assert_errors(["test must be even"], contract.conform(%{test: 311}))
+      assert_errors(["test must be greater than 2"], contract.conform(%{test: 0}))
     end
   end
 end

--- a/test/contract/types/map_test.exs
+++ b/test/contract/types/map_test.exs
@@ -13,8 +13,7 @@ defmodule Drops.Contract.Types.MapTest do
     end
 
     test "returns error with a non-map value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:map, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a map"], contract.conform(%{test: 312}))
     end
   end
 
@@ -30,8 +29,7 @@ defmodule Drops.Contract.Types.MapTest do
     end
 
     test "returns error with a non-map value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :filled?, [%{}]}}]} =
-               contract.conform(%{test: %{}})
+      assert_errors(["test must be a map"], contract.conform(%{test: 312}))
     end
   end
 end

--- a/test/contract/types/string_test.exs
+++ b/test/contract/types/string_test.exs
@@ -13,8 +13,7 @@ defmodule Drops.Contract.Types.StringTest do
     end
 
     test "returns error with a non-string value", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :type?, [:string, 312]}}]} =
-               contract.conform(%{test: 312})
+      assert_errors(["test must be a string"], contract.conform(%{test: 312}))
     end
   end
 
@@ -30,7 +29,7 @@ defmodule Drops.Contract.Types.StringTest do
     end
 
     test "returns error with an empty string", %{contract: contract} do
-      assert {:error, [{:error, {[:test], :filled?, [""]}}]} = contract.conform(%{test: ""})
+      assert_errors(["test must be filled"], contract.conform(%{test: ""}))
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -3,7 +3,13 @@ defmodule Drops.ContractCase do
 
   using do
     quote do
+      alias Drops.Contract.Messages.DefaultBackend, as: MessageBackend
+
       import Drops.ContractCase
+
+      def assert_errors(errors, {:error, results}) do
+        assert errors == MessageBackend.errors(results) |> Enum.map(&to_string/1)
+      end
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,8 +7,8 @@ defmodule Drops.ContractCase do
 
       import Drops.ContractCase
 
-      def assert_errors(errors, {:error, results}) do
-        assert errors == MessageBackend.errors(results) |> Enum.map(&to_string/1)
+      def assert_errors(errors, {:error, messages}) do
+        assert errors == Enum.map(messages, &to_string/1)
       end
     end
   end


### PR DESCRIPTION
This adds an error message backend that translates raw error tuples into user-friendly messages.

```elixir
defmodule UserContract do
  use Drops.Contract

  schema do
    %{
      required(:name) => string(),
      required(:age) => integer(),
      required(:active) => boolean(),
      required(:tags) => list(string()),
      required(:settings) => map(:string),
      required(:address) => maybe(:string)
    }
  end
end

{:error, errors} = UserContract.conform(
  %{name: "Jane", age: 42, active: true, tags: ["red", :oops, "blue"], address: []}
)
{:error,
 [
   %Drops.Contract.Messages.Error.Sum{
     left: %Drops.Contract.Messages.Error.Type{
       path: [:address],
       text: "must be nil",
       meta: %{args: [nil, []], predicate: :type?}
     },
     right: %Drops.Contract.Messages.Error.Type{
       path: [:address],
       text: "must be a string",
       meta: %{args: [:string, []], predicate: :type?}
     }
   },
   %Drops.Contract.Messages.Error.Type{
     path: [:settings],
     text: "key must be present",
     meta: %{args: [:settings], predicate: :has_key?}
   },
   %Drops.Contract.Messages.Error.Type{
     path: [:tags, 1],
     text: "must be a string",
     meta: %{args: [:string, :oops], predicate: :type?}
   }
 ]}

Enum.map(errors, &to_string/1)
["address must be nil or address must be a string",
 "settings key must be present", "tags.1 must be a string"]
```