### PR TITLE
Simplify and unify result tuples

### DIFF
--- a/lib/drops/predicates/helpers.ex
+++ b/lib/drops/predicates/helpers.ex
@@ -20,15 +20,17 @@ defmodule Drops.Predicates.Helpers do
     if apply(Predicates, name, apply_args) do
       {:ok, value}
     else
-      if is_list(value) do
-        {:error, [input: value, predicate: name, args: apply_args]}
-      else
-        {:error, {value, predicate: name, args: apply_args}}
-      end
+      {:error, [input: value, predicate: name, args: apply_args]}
     end
   end
 
   def apply_predicate(_, {:error, _} = error) do
     error
   end
+
+  def is_ok(results) when is_list(results), do: Enum.all?(results, &is_ok/1)
+  def is_ok(:ok), do: true
+  def is_ok({:ok, _}), do: true
+  def is_ok(:error), do: false
+  def is_ok({:error, _}), do: false
 end

--- a/lib/drops/types/list.ex
+++ b/lib/drops/types/list.ex
@@ -35,47 +35,18 @@ defmodule Drops.Types.List do
 
   defimpl Validator, for: List do
     def validate(%{constraints: constraints, member_type: member_type}, data) do
-      case apply_predicates(data, constraints) do
+      case Predicates.Helpers.apply_predicates(data, constraints) do
         {:ok, members} ->
           results = Enum.map(members, &Validator.validate(member_type, &1))
-          errors = Enum.reject(results, &is_ok/1)
+          errors = Enum.reject(results, &Predicates.Helpers.is_ok/1)
 
           if Enum.empty?(errors),
             do: {:ok, {:list, results}},
             else: {:error, {:list, results}}
 
-        {:error, result} ->
-          {:error, {:list, result}}
+        result ->
+          result
       end
     end
-
-    defp apply_predicates(value, predicates) do
-      Enum.reduce(predicates, {:ok, value}, &apply_predicate(&1, &2))
-    end
-
-    defp apply_predicate({:predicate, {name, args}}, {:ok, value}) do
-      apply_args =
-        case args do
-          [arg] -> [arg, value]
-          [] -> [value]
-          arg -> [arg, value]
-        end
-
-      if apply(Predicates, name, apply_args) do
-        {:ok, value}
-      else
-        {:error, {value, predicate: name, args: apply_args}}
-      end
-    end
-
-    defp apply_predicate(_, {:error, _} = error) do
-      error
-    end
-
-    defp is_ok(results) when is_list(results), do: Enum.all?(results, &is_ok/1)
-    defp is_ok(:ok), do: true
-    defp is_ok({:ok, _}), do: true
-    defp is_ok(:error), do: false
-    defp is_ok({:error, _}), do: false
   end
 end

--- a/lib/drops/types/map/key.ex
+++ b/lib/drops/types/map/key.ex
@@ -16,7 +16,7 @@ defmodule Drops.Types.Map.Key do
       nest_result(result, path)
     else
       case presence do
-        :required -> {:error, {path, {data, [predicate: :has_key?, args: []]}}}
+        :required -> {:error, {path, [input: data, predicate: :has_key?, args: [path]]}}
         :optional -> :ok
       end
     end

--- a/lib/drops/validator/messages/error.ex
+++ b/lib/drops/validator/messages/error.ex
@@ -51,7 +51,8 @@ defmodule Drops.Validator.Messages.Error do
     defstruct [:left, :right]
 
     defimpl String.Chars, for: Sum do
-      def to_string(%Error.Sum{left: left, right: right}) when is_list(left) and is_list(right) do
+      def to_string(%Error.Sum{left: left, right: right})
+          when is_list(left) and is_list(right) do
         "#{Enum.map(left, &Kernel.to_string/1)} or #{Enum.map(right, &Kernel.to_string/1)}"
       end
 

--- a/test/contract/messages_test.exs
+++ b/test/contract/messages_test.exs
@@ -18,7 +18,7 @@ defmodule Drops.Validator.MessagesTest do
                contract.conform(%{name: "Jane Doe"})
 
       assert path == [:age]
-      assert meta == [predicate: :has_key?, args: []]
+      assert meta == [predicate: :has_key?, args: [[:age]]]
       assert to_string(error) == "age key must be present"
     end
   end


### PR DESCRIPTION
This moves the predicate input value to the meta portion of the result tuple. Previously it caused issues as it was hard to differentiate path from input value.

In general, result tuples shouldn't use values as left-side of a tuple. These positions should be reserved for defining types of information that a tuple carry. ie `{:error, {:map, meta}}` uses `:map` to indicate it's a map result.