### PR TITLE
Add support for defining custom map types

### DIFF
--- a/test/contract/types/custom_test.exs
+++ b/test/contract/types/custom_test.exs
@@ -41,4 +41,31 @@ defmodule Drops.Contract.Types.CustomTest do
       assert_errors(["test must be filled"], contract.conform(%{test: ""}))
     end
   end
+
+  describe "using a custom map type" do
+    defmodule User do
+      use Drops.Type, %{
+        required(:name) => string()
+      }
+    end
+
+    contract do
+      schema do
+        %{required(:user) => User}
+      end
+    end
+
+    test "returns success with a valid input", %{contract: contract} do
+      assert {:ok, %{user: %{name: "John"}}} = contract.conform(%{user: %{name: "John"}})
+    end
+
+    test "returns errors with invalid input", %{contract: contract} do
+      assert_errors(["user must be a map"], contract.conform(%{user: 312}))
+
+      assert_errors(
+        ["user.name must be a string"],
+        contract.conform(%{user: %{name: 312}})
+      )
+    end
+  end
 end


### PR DESCRIPTION
This builds on top of the custom type API and allows you to define a custom **map** type, like this:

```elixir
defmodule User do
  use Drops.Type, %{
    required(:name) => string(),
    optional(:age) => integer()
  }
end

defmodule AccountContract do
  use Drops.Contract

  schema do
    %{
      required(:account) => %{
        required(:user) => User
      }
    }
  end
end
```