### PR TITLE
Custom union types

### DIFF
--- a/lib/drops/contract.ex
+++ b/lib/drops/contract.ex
@@ -63,7 +63,8 @@ defmodule Drops.Contract do
             output = to_output(result)
             errors = if outcome == :ok, do: [], else: Enum.reject(items, &ok?/1)
 
-            all_errors = if Enum.empty?(path), do: errors ++ apply_rules(output), else: errors
+            all_errors =
+              if Enum.empty?(path), do: errors ++ apply_rules(output), else: errors
 
             if length(all_errors) > 0 do
               {:error, @message_backend.errors(all_errors)}
@@ -76,7 +77,7 @@ defmodule Drops.Contract do
         end
       end
 
-      def conform(data, %Types.Sum{} = type, path: path) do
+      def conform(data, %Types.Union{} = type, path: path) do
         case conform(data, type.left, path: path) do
           {:ok, output} = success ->
             success

--- a/lib/drops/type.ex
+++ b/lib/drops/type.ex
@@ -30,6 +30,12 @@ defmodule Drops.Type do
     end
   end
 
+  defmacro __using__({:union, _, _} = spec) do
+    quote do
+      use Drops.Types.Sum, unquote(spec)
+    end
+  end
+
   defmacro __using__(spec) do
     quote do
       import Drops.Type
@@ -101,6 +107,7 @@ defmodule Drops.Type do
   def infer_primitive(map) when is_map(map), do: :map
   def infer_primitive(name) when is_atom(name), do: name
   def infer_primitive({:type, {name, _}}), do: name
+  def infer_primitive(_), do: nil
 
   def infer_constraints([]), do: []
   def infer_constraints(map) when is_map(map), do: []

--- a/lib/drops/type.ex
+++ b/lib/drops/type.ex
@@ -32,7 +32,7 @@ defmodule Drops.Type do
 
   defmacro __using__({:union, _, _} = spec) do
     quote do
-      use Drops.Types.Sum, unquote(spec)
+      use Drops.Types.Union, unquote(spec)
     end
   end
 

--- a/lib/drops/type/compiler.ex
+++ b/lib/drops/type/compiler.ex
@@ -5,7 +5,7 @@ defmodule Drops.Type.Compiler do
   """
   alias Drops.Types.{
     Primitive,
-    Sum,
+    Union,
     List,
     Cast,
     Map,
@@ -23,8 +23,8 @@ defmodule Drops.Type.Compiler do
     Map.new(keys, opts)
   end
 
-  def visit({:sum, {left, right}}, opts) do
-    Sum.new(visit(left, opts), visit(right, opts))
+  def visit({:union, {left, right}}, opts) do
+    Union.new(visit(left, opts), visit(right, opts))
   end
 
   def visit({:type, {:list, member_type}}, opts)
@@ -41,15 +41,15 @@ defmodule Drops.Type.Compiler do
   end
 
   def visit([left, right], opts) when is_tuple(left) and is_tuple(right) do
-    Sum.new(visit(left, opts), visit(right, opts))
+    Union.new(visit(left, opts), visit(right, opts))
   end
 
   def visit([left, right], opts) when is_map(left) and is_map(right) do
-    Sum.new(visit(left, opts), visit(right, opts))
+    Union.new(visit(left, opts), visit(right, opts))
   end
 
   def visit([left, right], _opts) do
-    Sum.new(left, right)
+    Union.new(left, right)
   end
 
   def visit(mod, opts) when is_atom(mod) do

--- a/lib/drops/type/dsl.ex
+++ b/lib/drops/type/dsl.ex
@@ -153,7 +153,7 @@ defmodule Drops.Type.DSL do
   def union([type | rest], predicates \\ []) do
     case rest do
       [] -> type(type, predicates)
-      _ -> {:sum, {type(type, predicates), type(rest, predicates)}}
+      _ -> {:union, {type(type, predicates), type(rest, predicates)}}
     end
   end
 
@@ -165,7 +165,7 @@ defmodule Drops.Type.DSL do
       # a list with a specified member type
       list(:string)
 
-      # a list with a specified sum member type
+      # a list with a specified union member type
       list([:string, :integer])
 
   """
@@ -227,7 +227,7 @@ defmodule Drops.Type.DSL do
   @spec maybe(map()) :: [type()]
 
   def maybe(schema) when is_map(schema) do
-    {:sum, {type(nil), schema}}
+    {:union, {type(nil), schema}}
   end
 
   @doc ~S"""

--- a/lib/drops/types/sum.ex
+++ b/lib/drops/types/sum.ex
@@ -1,11 +1,11 @@
-defmodule Drops.Types.Sum do
+defmodule Drops.Types.Union do
   @moduledoc ~S"""
-  Drops.Types.Sum is a struct that represents a sum type with left and right types.
+  Drops.Types.Union is a struct that represents a union type with left and right types.
 
   ## Examples
 
       iex> Drops.Type.Compiler.visit([{:type, {:string, []}}, {:type, {:integer, []}}], [])
-      %Drops.Types.Sum{
+      %Drops.Types.Union{
         left: %Drops.Types.Primitive{
           primitive: :string,
           constraints: [predicate: {:type?, :string}]
@@ -43,10 +43,10 @@ defmodule Drops.Types.Sum do
         deftype([:left, :right, :opts])
 
         alias Drops.Type.Compiler
-        import Drops.Types.Sum
+        import Drops.Types.Union
 
         def new(opts) do
-          {:sum, {left, right}} = unquote(spec)
+          {:union, {left, right}} = unquote(spec)
 
           struct(__MODULE__, %{
             left: Compiler.visit(left, opts),
@@ -70,7 +70,7 @@ defmodule Drops.Types.Sum do
     end
   end
 
-  defimpl Drops.Type.Validator, for: Sum do
+  defimpl Drops.Type.Validator, for: Union do
     def validate(type, input), do: Validator.validate(type, input)
   end
 end

--- a/lib/drops/validator/messages/backend.ex
+++ b/lib/drops/validator/messages/backend.ex
@@ -137,7 +137,7 @@ defmodule Drops.Validator.Messages.Backend do
       end
 
       defp error({:error, {:or, {left, right}}}) do
-        %Error.Sum{left: error(left), right: error(right)}
+        %Error.Union{left: error(left), right: error(right)}
       end
 
       defp error({:error, {path, {:or, {left, right}}}}) do

--- a/lib/drops/validator/messages/error.ex
+++ b/lib/drops/validator/messages/error.ex
@@ -44,33 +44,33 @@ defmodule Drops.Validator.Messages.Error do
     end
   end
 
-  defmodule Sum do
+  defmodule Union do
     @moduledoc false
     @type t :: %__MODULE__{}
 
     defstruct [:left, :right]
 
-    defimpl String.Chars, for: Sum do
-      def to_string(%Error.Sum{left: left, right: right})
+    defimpl String.Chars, for: Union do
+      def to_string(%Error.Union{left: left, right: right})
           when is_list(left) and is_list(right) do
         "#{Enum.map(left, &Kernel.to_string/1)} or #{Enum.map(right, &Kernel.to_string/1)}"
       end
 
-      def to_string(%Error.Sum{left: left, right: right}) when is_list(left) do
+      def to_string(%Error.Union{left: left, right: right}) when is_list(left) do
         "#{Enum.map(left, &Kernel.to_string/1)} or #{right}"
       end
 
-      def to_string(%Error.Sum{left: left, right: right}) when is_list(right) do
+      def to_string(%Error.Union{left: left, right: right}) when is_list(right) do
         "#{left} or #{Enum.map(right, &Kernel.to_string/1)}"
       end
 
-      def to_string(%Error.Sum{left: left, right: right}) do
+      def to_string(%Error.Union{left: left, right: right}) do
         "#{left} or #{right}"
       end
     end
 
-    defimpl Error.Conversions, for: Sum do
-      def nest(%Error.Sum{left: left, right: right} = error, root) do
+    defimpl Error.Conversions, for: Union do
+      def nest(%Error.Union{left: left, right: right} = error, root) do
         Map.merge(error, %{
           left: Error.Conversions.nest(left, root),
           right: Error.Conversions.nest(right, root)

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,7 @@ defmodule Drops.MixProject do
           Drops.Types.Map,
           Drops.Types.Map.Key,
           Drops.Type.DSL,
-          Drops.Types.Sum,
+          Drops.Types.Union,
           Drops.Types.Cast
         ]
       ]

--- a/test/contract/messages_test.exs
+++ b/test/contract/messages_test.exs
@@ -71,7 +71,7 @@ defmodule Drops.Validator.MessagesTest do
       assert to_string(error) == "role must be one of: admin, user"
     end
 
-    test "returns errors from a sum type", %{contract: contract} do
+    test "returns errors from a union type", %{contract: contract} do
       assert {:error, [error = %{left: left_error, right: right_error}]} =
                contract.conform(%{birthday: "oops"})
 

--- a/test/contract/schema_test.exs
+++ b/test/contract/schema_test.exs
@@ -370,7 +370,7 @@ defmodule Drops.Contract.SchemaTest do
     end
   end
 
-  describe "nested sum of schemas" do
+  describe "nested union of schemas" do
     contract do
       schema do
         %{
@@ -395,7 +395,7 @@ defmodule Drops.Contract.SchemaTest do
     end
   end
 
-  describe "nested sum of schemas when atomized" do
+  describe "nested union of schemas when atomized" do
     contract do
       schema(atomize: true) do
         %{
@@ -423,7 +423,7 @@ defmodule Drops.Contract.SchemaTest do
     end
   end
 
-  describe "using list shortcut for sum types" do
+  describe "using list shortcut for union types" do
     contract do
       schema(:left) do
         %{required(:name) => string()}
@@ -453,7 +453,7 @@ defmodule Drops.Contract.SchemaTest do
     end
   end
 
-  describe "sum of lists" do
+  describe "union of lists" do
     contract do
       schema do
         %{
@@ -480,7 +480,7 @@ defmodule Drops.Contract.SchemaTest do
     end
   end
 
-  describe "sum of list of schemas" do
+  describe "union of list of schemas" do
     contract do
       schema(:left) do
         %{required(:name) => string()}
@@ -513,7 +513,7 @@ defmodule Drops.Contract.SchemaTest do
     end
   end
 
-  describe "sum of list of schemas nested" do
+  describe "union of list of schemas nested" do
     contract do
       schema(:left) do
         %{required(:name) => string()}
@@ -560,7 +560,7 @@ defmodule Drops.Contract.SchemaTest do
     end
   end
 
-  describe "sum of schemas" do
+  describe "union of schemas" do
     contract do
       schema(:left) do
         %{required(:name) => string()}

--- a/test/contract/types/custom_test.exs
+++ b/test/contract/types/custom_test.exs
@@ -42,6 +42,59 @@ defmodule Drops.Contract.Types.CustomTest do
     end
   end
 
+  describe "defining a sum type using atoms" do
+    defmodule Number do
+      use Drops.Type, union([:integer, :float])
+    end
+
+    contract do
+      schema do
+        %{required(:test) => Number}
+      end
+    end
+
+    test "returns success with a valid input", %{contract: contract} do
+      assert {:ok, %{test: 1}} = contract.conform(%{test: 1})
+      assert {:ok, %{test: 1.0}} = contract.conform(%{test: 1.0})
+    end
+
+    test "returns errors with invalid input", %{contract: contract} do
+      assert_errors(
+        ["test must be an integer or test must be a float"],
+        contract.conform(%{test: "Hello World"})
+      )
+    end
+  end
+
+  describe "defining a sum type using types" do
+    defmodule PositiveNumber do
+      use Drops.Type, union([integer(), float()], gt?: 0)
+    end
+
+    contract do
+      schema do
+        %{required(:test) => PositiveNumber}
+      end
+    end
+
+    test "returns success with a valid input", %{contract: contract} do
+      assert {:ok, %{test: 1}} = contract.conform(%{test: 1})
+      assert {:ok, %{test: 1.0}} = contract.conform(%{test: 1.0})
+    end
+
+    test "returns errors with invalid input", %{contract: contract} do
+      assert_errors(
+        ["test must be an integer or test must be a float"],
+        contract.conform(%{test: "Hello World"})
+      )
+
+      assert_errors(
+        ["test must be greater than 0 or test must be a float"],
+        contract.conform(%{test: -1})
+      )
+    end
+  end
+
   describe "using a custom map type" do
     defmodule User do
       use Drops.Type, %{

--- a/test/contract/types/custom_test.exs
+++ b/test/contract/types/custom_test.exs
@@ -42,7 +42,7 @@ defmodule Drops.Contract.Types.CustomTest do
     end
   end
 
-  describe "defining a sum type using atoms" do
+  describe "defining a union type using atoms" do
     defmodule Number do
       use Drops.Type, union([:integer, :float])
     end
@@ -66,7 +66,7 @@ defmodule Drops.Contract.Types.CustomTest do
     end
   end
 
-  describe "defining a sum type using types" do
+  describe "defining a union type using types" do
     defmodule PositiveNumber do
       use Drops.Type, union([integer(), float()], gt?: 0)
     end


### PR DESCRIPTION
This adds support for defining custom union types, like this:

```elixir
defmodule PositiveNumber do
  use Drops.Type, union([integer(), float()], gt?: 0)
end
```

Closes #37 