### PR TITLE
Add support for defining type opts in the DSL

### DIFF
--- a/lib/drops/type.ex
+++ b/lib/drops/type.ex
@@ -43,7 +43,8 @@ defmodule Drops.Type do
 
       deftype(
         primitive: Type.infer_primitive(unquote(spec)),
-        constraints: Type.infer_constraints(unquote(spec))
+        constraints: Type.infer_constraints(unquote(spec)),
+        opts: []
       )
 
       def new(attributes) when is_list(attributes) do
@@ -78,7 +79,8 @@ defmodule Drops.Type do
     quote do
       deftype(
         primitive: unquote(primitive),
-        constraints: type(unquote(primitive))
+        constraints: type(unquote(primitive)),
+        opts: []
       )
     end
   end

--- a/lib/drops/type/compiler.ex
+++ b/lib/drops/type/compiler.ex
@@ -24,7 +24,7 @@ defmodule Drops.Type.Compiler do
   end
 
   def visit({:union, {left, right}}, opts) do
-    Union.new(visit(left, opts), visit(right, opts))
+    Union.new(visit(left, opts), visit(right, opts), opts)
   end
 
   def visit({:type, {:list, member_type}}, opts)
@@ -56,7 +56,11 @@ defmodule Drops.Type.Compiler do
     mod.new(opts)
   end
 
-  def visit(spec, _opts) when is_tuple(spec) do
-    Primitive.new(spec)
+  def visit({:opts, {type, opts}}, more_opts) do
+    visit(type, Keyword.merge(more_opts, opts))
+  end
+
+  def visit(spec, opts) when is_tuple(spec) do
+    Elixir.Map.merge(Primitive.new(spec), %{opts: opts})
   end
 end

--- a/lib/drops/type/dsl.ex
+++ b/lib/drops/type/dsl.ex
@@ -6,6 +6,7 @@ defmodule Drops.Type.DSL do
   """
 
   @type type() :: {:type, {atom(), keyword()}}
+  @type opts() :: {:opts, {type(), keyword()}}
 
   @doc ~S"""
   Returns a required key specification.
@@ -431,5 +432,21 @@ defmodule Drops.Type.DSL do
 
   def map(predicates) when is_list(predicates) do
     type(:map, predicates)
+  end
+
+  @doc ~S"""
+  Add options to a type specification.
+
+  ## Examples
+
+      # a string with a custom name
+      opts(string(:filled?), name: :email)
+  """
+  @doc since: "0.2.0"
+
+  @spec opts(type(), Keyword.t()) :: opts()
+
+  def opts(type, opts) do
+    {:opts, {type, opts}}
   end
 end

--- a/lib/drops/types/union.ex
+++ b/lib/drops/types/union.ex
@@ -85,8 +85,8 @@ defmodule Drops.Types.Union do
   use Drops.Type do
     deftype([:left, :right, :opts])
 
-    def new(left, right) when is_struct(left) and is_struct(right) do
-      struct(__MODULE__, left: left, right: right)
+    def new(left, right, opts \\ []) when is_struct(left) and is_struct(right) do
+      struct(__MODULE__, left: left, right: right, opts: opts)
     end
   end
 

--- a/test/contract/type_test.exs
+++ b/test/contract/type_test.exs
@@ -86,4 +86,19 @@ defmodule Drops.Contract.TypeTest do
       )
     end
   end
+
+  describe "type/1 with a type atom and options" do
+    contract do
+      schema do
+        %{required(:test) => opts(type(:string, [:filled?]), name: :test_name)}
+      end
+    end
+
+    test "returns success with valid data", %{contract: contract} do
+      [key] = contract.schema().keys
+      %{opts: opts} = key.type
+
+      assert Keyword.get(opts, :name) == :test_name
+    end
+  end
 end

--- a/test/contract/types/string_test.exs
+++ b/test/contract/types/string_test.exs
@@ -32,4 +32,19 @@ defmodule Drops.Contract.Types.StringTest do
       assert_errors(["test must be filled"], contract.conform(%{test: ""}))
     end
   end
+
+  describe "string/1 with a type atom and options" do
+    contract do
+      schema do
+        %{required(:test) => opts(string(:filled?), name: :test_name)}
+      end
+    end
+
+    test "returns success with valid data", %{contract: contract} do
+      [key] = contract.schema().keys
+      %{opts: opts} = key.type
+
+      assert Keyword.get(opts, :name) == :test_name
+    end
+  end
 end

--- a/test/contract/types/union_test.exs
+++ b/test/contract/types/union_test.exs
@@ -114,4 +114,22 @@ defmodule Drops.Contract.Types.UnionTest do
       )
     end
   end
+
+  describe "a union of two primitive types and with opts" do
+    contract do
+      schema do
+        %{
+          required(:test) =>
+            union([string(size?: 5), integer(gt?: 0)]) |> opts(name: :str_or_int)
+        }
+      end
+    end
+
+    test "returns success when left side is a success", %{contract: contract} do
+      [key] = contract.schema().keys
+      %{opts: opts} = key.type
+
+      assert Keyword.get(opts, :name) == :str_or_int
+    end
+  end
 end


### PR DESCRIPTION
This is a handy way of defining opts at the DSL level, which means you won't have to define custom types just to tweak some default opts:

```elixir
%{required(:admin) => opts(bool(), default: false)}

# or with a pipe op (looks nicer in case of types with predicate constraints)
%{required(:login) => string(:filled?) |> opts(error: "Login is srsly needed"))
```