### PR TITLE
Introduce Ecto schema inference

### DIFF
--- a/examples/ecto/schema-inference-01.ex
+++ b/examples/ecto/schema-inference-01.ex
@@ -1,0 +1,30 @@
+defmodule UserSchema do
+  use Ecto.Schema
+
+  schema "users" do
+    field(:name, :string)
+    field(:email, :string)
+    field(:age, :integer)
+
+    timestamps()
+  end
+end
+
+defmodule UserContract do
+  use Drops.Contract
+
+  schema(UserSchema)
+end
+
+UserContract.conform(%{name: "Jane", email: "jane@doe.org", age: 21})
+# {:ok, %{age: 21, email: "jane@doe.org", name: "Jane"}}
+
+UserContract.conform(%{name: "Jane", email: "jane@doe.org", age: "21"})
+# {:error,
+#  [
+#    %Drops.Validator.Messages.Error.Type{
+#      path: [:age],
+#      text: "must be an integer",
+#      meta: [predicate: :type?, args: [:integer, "21"]]
+#    }
+#  ]}

--- a/lib/drops/schema/inference/ecto.ex
+++ b/lib/drops/schema/inference/ecto.ex
@@ -1,0 +1,251 @@
+defimpl Drops.Schema.Compiler, for: Atom do
+  @moduledoc """
+  Custom compiler for Ecto schema modules.
+
+  This implementation adds the source Ecto schema module to the compiled
+  Map type's meta field, allowing users to access the original schema
+  information after compilation.
+  """
+
+  alias Drops.Type.Compiler, as: DefaultCompiler
+
+  @doc """
+  Compile a schema AST from an Ecto schema module with meta information.
+
+  This function compiles the schema AST using the default compiler but
+  adds the source Ecto schema module to the resulting Map type's meta field.
+
+  ## Parameters
+
+  - `ecto_schema_module` - The Ecto schema module that was used for inference
+  - `schema_ast` - The schema AST returned by inference
+  - `opts` - Compilation options
+
+  ## Returns
+
+  Returns a compiled Map type with the source schema in its meta field.
+  """
+  def compile(ecto_schema_module, schema_ast, opts) when is_atom(ecto_schema_module) do
+    # Check if this is an Ecto schema module
+    if ecto_schema_module?(ecto_schema_module) do
+      # Add the source schema to the meta field
+      opts_with_meta =
+        Keyword.update(
+          opts,
+          :meta,
+          %{source_schema: ecto_schema_module},
+          fn existing_meta ->
+            Map.put(existing_meta, :source_schema, ecto_schema_module)
+          end
+        )
+
+      # Use the default compiler with the enhanced options
+      DefaultCompiler.visit(schema_ast, opts_with_meta)
+    else
+      # For non-Ecto atoms, use the default compiler as-is
+      DefaultCompiler.visit(schema_ast, opts)
+    end
+  end
+
+  # Private helper function
+  defp ecto_schema_module?(module) do
+    Code.ensure_loaded?(module) and
+      function_exported?(module, :__schema__, 1)
+  end
+end
+
+defimpl Drops.Schema.Inference, for: Atom do
+  @moduledoc """
+  Schema inference implementation for Ecto schema modules.
+
+  This implementation handles the inference of schemas from Ecto schema modules
+  by introspecting their field definitions and converting them to Drops schema format.
+
+  ## Examples
+
+      # Given an Ecto schema:
+      defmodule User do
+        use Ecto.Schema
+
+        schema "users" do
+          field(:name, :string)
+          field(:email, :string)
+          field(:age, :integer)
+          timestamps()
+        end
+      end
+
+      # Inference will produce:
+      %{
+        required(:name) => string(),
+        required(:email) => string(),
+        required(:age) => integer()
+      }
+
+  ## Field Filtering
+
+  By default, the following fields are excluded from inference:
+  - `:id` - Primary key field
+  - `:inserted_at` - Timestamp field
+  - `:updated_at` - Timestamp field
+
+  This can be customized via options.
+
+  ## Field Presence
+
+  By default, all fields are marked as required. This can be customized
+  by providing field presence configuration in the options.
+  """
+
+  import Drops.Type.DSL
+
+  @doc """
+  Infer schema from an Ecto schema module.
+
+  ## Parameters
+
+  - `module` - An Ecto schema module
+  - `opts` - Options for inference:
+    - `:exclude_fields` - List of field names to exclude (default: `[:id, :inserted_at, :updated_at]`)
+    - `:field_presence` - Map of field names to presence (`:required` or `:optional`)
+    - `:default_presence` - Default presence for fields (default: `:required`)
+
+  ## Returns
+
+  Returns a Map schema definition compatible with Drops.
+
+  ## Examples
+
+      # Basic inference
+      Drops.Schema.Inference.infer_schema(MyApp.User, [])
+
+      # Custom field presence
+      Drops.Schema.Inference.infer_schema(MyApp.User,
+        field_presence: %{name: :required, email: :required},
+        default_presence: :optional
+      )
+
+      # Include all fields
+      Drops.Schema.Inference.infer_schema(MyApp.User, exclude_fields: [])
+  """
+  def infer_schema(module, opts) when is_atom(module) do
+    # Check if this is an Ecto schema module
+    if ecto_schema_module?(module) do
+      infer_ecto_schema(module, opts)
+    else
+      # For non-Ecto atoms, we can't infer a schema
+      raise ArgumentError,
+            "Cannot infer schema from atom #{inspect(module)} - not an Ecto schema module"
+    end
+  end
+
+  # Private functions
+
+  defp ecto_schema_module?(module) do
+    Code.ensure_loaded?(module) and
+      function_exported?(module, :__schema__, 1)
+  end
+
+  defp infer_ecto_schema(module, opts) do
+    field_presence = Keyword.get(opts, :field_presence, %{})
+    default_presence = Keyword.get(opts, :default_presence, :required)
+
+    # Get all fields from the Ecto schema
+    all_fields = module.__schema__(:fields)
+
+    # Determine which fields to include
+    fields =
+      if accept_fields = Keyword.get(opts, :accept) do
+        # If :accept is specified, only include those fields
+        Enum.filter(all_fields, &(&1 in accept_fields))
+      else
+        # Otherwise, use the existing exclude_fields logic
+        default_exclude = [:id, :inserted_at, :updated_at]
+
+        # If exclude_fields is explicitly provided, use it as-is
+        # Otherwise, use the default exclusions
+        exclude_fields =
+          if Keyword.has_key?(opts, :exclude_fields) do
+            user_exclude = Keyword.get(opts, :exclude_fields)
+            # If user provides an empty list, they want all fields
+            if user_exclude == [] do
+              []
+            else
+              # Combine user exclusions with defaults
+              (default_exclude ++ user_exclude) |> Enum.uniq()
+            end
+          else
+            default_exclude
+          end
+
+        # Filter out excluded fields
+        Enum.reject(all_fields, &(&1 in exclude_fields))
+      end
+
+    # Convert each field to a Drops schema entry
+    field_entries =
+      Enum.map(fields, fn field ->
+        field_type = module.__schema__(:type, field)
+        drops_type = ecto_type_to_drops_type(field_type)
+
+        # Determine field presence
+        presence = Map.get(field_presence, field, default_presence)
+
+        presence_key =
+          case presence do
+            :required -> required(field)
+            :optional -> optional(field)
+            # Default to optional for unknown values
+            _ -> optional(field)
+          end
+
+        {presence_key, drops_type}
+      end)
+
+    # Return a map with the field entries
+    Map.new(field_entries)
+  end
+
+  # Type mapping from Ecto types to Drops types
+
+  # Basic primitive types
+  defp ecto_type_to_drops_type(:string), do: string()
+  defp ecto_type_to_drops_type(:integer), do: integer()
+  defp ecto_type_to_drops_type(:float), do: float()
+  defp ecto_type_to_drops_type(:boolean), do: boolean()
+
+  # ID types
+  defp ecto_type_to_drops_type(:id), do: integer()
+  defp ecto_type_to_drops_type(:binary_id), do: string()
+
+  # Binary types
+  defp ecto_type_to_drops_type(:binary), do: string()
+  defp ecto_type_to_drops_type(:bitstring), do: string()
+
+  # Date and time types - now using proper Drops types
+  defp ecto_type_to_drops_type(:date), do: type(:date)
+  defp ecto_type_to_drops_type(:time), do: type(:time)
+  defp ecto_type_to_drops_type(:time_usec), do: type(:time)
+  defp ecto_type_to_drops_type(:naive_datetime), do: type(:date_time)
+  defp ecto_type_to_drops_type(:naive_datetime_usec), do: type(:date_time)
+  defp ecto_type_to_drops_type(:utc_datetime), do: type(:date_time)
+  defp ecto_type_to_drops_type(:utc_datetime_usec), do: type(:date_time)
+
+  # Duration type (Elixir 1.17+)
+  defp ecto_type_to_drops_type(:duration), do: any()
+
+  # Decimal type - using number() for better validation than any()
+  defp ecto_type_to_drops_type(:decimal), do: number()
+
+  # Handle array types
+  defp ecto_type_to_drops_type({:array, inner_type}) do
+    list(ecto_type_to_drops_type(inner_type), [])
+  end
+
+  # Handle map types
+  defp ecto_type_to_drops_type(:map), do: map()
+  defp ecto_type_to_drops_type({:map, _}), do: map()
+
+  # Fallback for unknown types
+  defp ecto_type_to_drops_type(_), do: any()
+end

--- a/lib/drops/types/map.ex
+++ b/lib/drops/types/map.ex
@@ -79,12 +79,13 @@ defmodule Drops.Types.Map do
   defmacro __using__(opts) do
     quote do
       use Drops.Type do
-        deftype(:map, keys: unquote(opts[:keys]), atomize: false)
+        deftype(:map, keys: unquote(opts[:keys]), atomize: false, meta: %{})
 
         import Drops.Types.Map
 
         def new(opts) do
-          struct(__MODULE__, opts)
+          opts_with_meta = Keyword.put_new(opts, :meta, %{})
+          struct(__MODULE__, opts_with_meta)
         end
 
         def new(predicates, opts) do
@@ -104,7 +105,7 @@ defmodule Drops.Types.Map do
   end
 
   use Drops.Type do
-    deftype(:map, keys: [], atomize: false)
+    deftype(:map, keys: [], atomize: false, meta: %{})
   end
 
   defimpl Drops.Type.Validator, for: Map do
@@ -113,7 +114,8 @@ defmodule Drops.Types.Map do
 
   def new(keys, opts) when is_list(keys) do
     atomize = opts[:atomize] || false
-    struct(__MODULE__, keys: keys, atomize: atomize)
+    meta = opts[:meta] || %{}
+    struct(__MODULE__, keys: keys, atomize: atomize, meta: meta)
   end
 
   def atomize(data, keys, initial \\ %{}) do

--- a/mix.exs
+++ b/mix.exs
@@ -92,7 +92,10 @@ defmodule Drops.MixProject do
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:doctor, "~> 0.21.0", only: :dev},
-      {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
+      {:ecto, "~> 3.10", optional: true},
+      {:ecto_sql, "~> 3.10", optional: true},
+      {:ecto_sqlite3, "~> 0.12", only: [:test, :dev]}
     ]
   end
 end

--- a/test/drops/schema/inference/ecto_test.exs
+++ b/test/drops/schema/inference/ecto_test.exs
@@ -1,0 +1,352 @@
+defmodule Drops.Schema.Inference.EctoTest do
+  use Drops.ContractCase
+
+  alias Drops.Schema.Inference
+  import Drops.Type.DSL
+
+  describe "Ecto schema inference" do
+    test "infers schema from Ecto schema module" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.UserSchema, [])
+
+      expected = %{
+        required(:name) => string(),
+        required(:email) => string()
+      }
+
+      assert result == expected
+    end
+
+    test "respects exclude_fields option" do
+      result =
+        Inference.infer_schema(Test.Ecto.TestSchemas.UserSchema, exclude_fields: [:email])
+
+      expected = %{
+        required(:name) => string()
+      }
+
+      assert result == expected
+    end
+
+    test "respects field_presence option" do
+      result =
+        Inference.infer_schema(Test.Ecto.TestSchemas.UserSchema,
+          field_presence: %{name: :required, email: :optional}
+        )
+
+      expected = %{
+        required(:name) => string(),
+        optional(:email) => string()
+      }
+
+      assert result == expected
+    end
+
+    test "respects default_presence option" do
+      result =
+        Inference.infer_schema(Test.Ecto.TestSchemas.UserSchema,
+          default_presence: :optional
+        )
+
+      expected = %{
+        optional(:name) => string(),
+        optional(:email) => string()
+      }
+
+      assert result == expected
+    end
+
+    test "includes all fields when exclude_fields is empty" do
+      result =
+        Inference.infer_schema(Test.Ecto.TestSchemas.UserSchema, exclude_fields: [])
+
+      # Should include id, inserted_at, updated_at fields
+      assert Map.has_key?(result, required(:id))
+      assert Map.has_key?(result, required(:inserted_at))
+      assert Map.has_key?(result, required(:updated_at))
+      assert Map.has_key?(result, required(:name))
+      assert Map.has_key?(result, required(:email))
+    end
+
+    test "raises error for non-Ecto schema modules" do
+      assert_raise ArgumentError, ~r/Cannot infer schema from atom/, fn ->
+        Inference.infer_schema(NonExistentModule, [])
+      end
+    end
+
+    test "raises error for non-schema atoms" do
+      assert_raise ArgumentError, ~r/not an Ecto schema module/, fn ->
+        Inference.infer_schema(String, [])
+      end
+    end
+  end
+
+  describe "Basic primitive types inference" do
+    test "infers basic primitive types correctly" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.BasicTypesSchema, [])
+
+      expected = %{
+        required(:string_field) => string(),
+        required(:integer_field) => integer(),
+        required(:float_field) => float(),
+        required(:boolean_field) => boolean(),
+        required(:binary_field) => string(),
+        required(:bitstring_field) => string()
+      }
+
+      assert result == expected
+    end
+  end
+
+  describe "ID types inference" do
+    test "infers ID types correctly" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.IdTypesSchema, [])
+
+      expected = %{
+        required(:id_field) => integer(),
+        required(:binary_id_field) => string()
+      }
+
+      assert result == expected
+    end
+  end
+
+  describe "Date and time types inference" do
+    test "infers date and time types correctly" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.DateTimeTypesSchema, [])
+
+      expected = %{
+        required(:date_field) => type(:date),
+        required(:time_field) => type(:time),
+        required(:time_usec_field) => type(:time),
+        required(:naive_datetime_field) => type(:date_time),
+        required(:naive_datetime_usec_field) => type(:date_time),
+        required(:utc_datetime_field) => type(:date_time),
+        required(:utc_datetime_usec_field) => type(:date_time)
+      }
+
+      assert result == expected
+    end
+  end
+
+  describe "Numeric types inference" do
+    test "infers numeric types correctly" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.NumericTypesSchema, [])
+
+      expected = %{
+        required(:decimal_field) => number(),
+        required(:integer_field) => integer(),
+        required(:float_field) => float()
+      }
+
+      assert result == expected
+    end
+  end
+
+  describe "Array types inference" do
+    test "infers array types correctly" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.ArrayTypesSchema, [])
+
+      expected = %{
+        required(:string_array) => list(string(), []),
+        required(:integer_array) => list(integer(), []),
+        required(:float_array) => list(float(), []),
+        required(:boolean_array) => list(boolean(), []),
+        required(:date_array) => list(type(:date), [])
+      }
+
+      assert result == expected
+    end
+  end
+
+  describe "Map types inference" do
+    test "infers map types correctly" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.MapTypesSchema, [])
+
+      expected = %{
+        required(:map_field) => map(),
+        required(:typed_map_field) => map()
+      }
+
+      assert result == expected
+    end
+  end
+
+  describe "Virtual fields handling" do
+    test "excludes virtual fields by default" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.VirtualFieldsSchema, [])
+
+      expected = %{
+        required(:name) => string()
+      }
+
+      assert result == expected
+      refute Map.has_key?(result, required(:computed_value))
+      refute Map.has_key?(result, required(:any_virtual))
+    end
+  end
+
+  describe "Timestamps handling" do
+    test "excludes timestamp fields by default" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.TimestampsSchema, [])
+
+      expected = %{
+        required(:name) => string()
+      }
+
+      assert result == expected
+      refute Map.has_key?(result, required(:inserted_at))
+      refute Map.has_key?(result, required(:updated_at))
+    end
+
+    test "includes timestamp fields when explicitly requested" do
+      result =
+        Inference.infer_schema(Test.Ecto.TestSchemas.TimestampsSchema, exclude_fields: [])
+
+      assert Map.has_key?(result, required(:id))
+      assert Map.has_key?(result, required(:name))
+      assert Map.has_key?(result, required(:inserted_at))
+      assert Map.has_key?(result, required(:updated_at))
+    end
+  end
+
+  describe "Primary key handling" do
+    test "excludes default primary key by default" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.TimestampsSchema, [])
+
+      refute Map.has_key?(result, required(:id))
+    end
+
+    test "handles custom primary key" do
+      result =
+        Inference.infer_schema(Test.Ecto.TestSchemas.CustomPrimaryKeySchema,
+          exclude_fields: []
+        )
+
+      assert Map.has_key?(result, required(:uuid))
+      assert Map.has_key?(result, required(:name))
+    end
+
+    test "handles schema without primary key" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.NoPrimaryKeySchema, [])
+
+      expected = %{
+        required(:name) => string(),
+        required(:value) => integer()
+      }
+
+      assert result == expected
+    end
+
+    test "handles composite primary key" do
+      result =
+        Inference.infer_schema(Test.Ecto.TestSchemas.CompositePrimaryKeySchema,
+          exclude_fields: []
+        )
+
+      expected = %{
+        required(:part1) => string(),
+        required(:part2) => integer(),
+        required(:data) => string()
+      }
+
+      assert result == expected
+    end
+  end
+
+  describe "Custom types handling" do
+    test "handles Ecto.UUID and Ecto.Enum as any() type" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.CustomTypesSchema, [])
+
+      expected = %{
+        required(:uuid_field) => any(),
+        required(:enum_field) => any()
+      }
+
+      assert result == expected
+    end
+  end
+
+  describe "Associations handling" do
+    test "excludes associations but includes foreign keys" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.AssociationsSchema, [])
+
+      expected = %{
+        required(:name) => string(),
+        required(:parent_id) => integer()
+      }
+
+      assert result == expected
+      # Association fields themselves are not included
+      refute Map.has_key?(result, required(:items))
+      refute Map.has_key?(result, required(:parent))
+    end
+  end
+
+  describe "Embedded schemas handling" do
+    test "handles embedded schemas correctly" do
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.EmbeddedTypesSchema, [])
+
+      expected = %{
+        required(:name) => string(),
+        required(:value) => integer()
+      }
+
+      assert result == expected
+    end
+
+    test "embedded schemas work with field presence options" do
+      result =
+        Inference.infer_schema(Test.Ecto.TestSchemas.EmbeddedTypesSchema,
+          field_presence: %{name: :required, value: :optional}
+        )
+
+      expected = %{
+        required(:name) => string(),
+        optional(:value) => integer()
+      }
+
+      assert result == expected
+    end
+  end
+
+  describe "Edge cases and error handling" do
+    test "handles empty schema gracefully" do
+      # Create a minimal schema for testing
+      defmodule EmptyTestSchema do
+        use Ecto.Schema
+
+        schema "empty" do
+        end
+      end
+
+      result = Inference.infer_schema(EmptyTestSchema, [])
+      assert result == %{}
+    end
+
+    test "handles schema with only excluded fields" do
+      result =
+        Inference.infer_schema(Test.Ecto.TestSchemas.BasicTypesSchema,
+          exclude_fields: [
+            :string_field,
+            :integer_field,
+            :float_field,
+            :boolean_field,
+            :binary_field,
+            :bitstring_field
+          ]
+        )
+
+      assert result == %{}
+    end
+
+    test "handles unknown field types gracefully" do
+      # This test ensures that unknown types fall back to any()
+      # The implementation should handle this via the fallback clause
+      result = Inference.infer_schema(Test.Ecto.TestSchemas.CustomTypesSchema, [])
+
+      # Custom types should map to any()
+      assert Map.get(result, required(:uuid_field)) == any()
+      assert Map.get(result, required(:enum_field)) == any()
+    end
+  end
+end

--- a/test/drops/schema/inference/map_test.exs
+++ b/test/drops/schema/inference/map_test.exs
@@ -1,4 +1,4 @@
-defmodule Drops.Schema.InferenceTest do
+defmodule Drops.Schema.Inference.MapTest do
   use Drops.ContractCase
 
   alias Drops.Schema.Inference

--- a/test/drops/schema_test.exs
+++ b/test/drops/schema_test.exs
@@ -27,14 +27,6 @@ defmodule Drops.SchemaTest do
     end
   end
 
-  describe "error handling" do
-    test "raises error for non-Ecto schema modules" do
-      assert_raise Protocol.UndefinedError, ~r/not implemented/, fn ->
-        Schema.infer_and_compile(NonExistentModule, [])
-      end
-    end
-  end
-
   describe "has_custom_compiler?/1" do
     test "returns false for types without custom compilers" do
       refute Schema.has_custom_compiler?(%{})

--- a/test/support/ecto/test_schemas.ex
+++ b/test/support/ecto/test_schemas.ex
@@ -1,0 +1,182 @@
+defmodule Test.Ecto.TestSchemas do
+  defmodule UserSchema do
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    schema "users" do
+      field(:name, :string)
+      field(:email, :string)
+
+      timestamps()
+    end
+
+    def changeset(user, attrs) do
+      user
+      |> cast(attrs, [:name, :email])
+      |> validate_required([:name])
+    end
+  end
+
+  defmodule BasicTypesSchema do
+    use Ecto.Schema
+
+    schema "basic_types" do
+      field(:string_field, :string)
+      field(:integer_field, :integer)
+      field(:float_field, :float)
+      field(:boolean_field, :boolean)
+      field(:binary_field, :binary)
+      field(:bitstring_field, :bitstring)
+    end
+  end
+
+  defmodule IdTypesSchema do
+    use Ecto.Schema
+
+    schema "id_types" do
+      field(:id_field, :id)
+      field(:binary_id_field, :binary_id)
+    end
+  end
+
+  defmodule DateTimeTypesSchema do
+    use Ecto.Schema
+
+    schema "datetime_types" do
+      field(:date_field, :date)
+      field(:time_field, :time)
+      field(:time_usec_field, :time_usec)
+      field(:naive_datetime_field, :naive_datetime)
+      field(:naive_datetime_usec_field, :naive_datetime_usec)
+      field(:utc_datetime_field, :utc_datetime)
+      field(:utc_datetime_usec_field, :utc_datetime_usec)
+    end
+  end
+
+  defmodule NumericTypesSchema do
+    use Ecto.Schema
+
+    schema "numeric_types" do
+      field(:decimal_field, :decimal)
+      field(:integer_field, :integer)
+      field(:float_field, :float)
+    end
+  end
+
+  defmodule ArrayTypesSchema do
+    use Ecto.Schema
+
+    schema "array_types" do
+      field(:string_array, {:array, :string})
+      field(:integer_array, {:array, :integer})
+      field(:float_array, {:array, :float})
+      field(:boolean_array, {:array, :boolean})
+      field(:date_array, {:array, :date})
+    end
+  end
+
+  defmodule MapTypesSchema do
+    use Ecto.Schema
+
+    schema "map_types" do
+      field(:map_field, :map)
+      field(:typed_map_field, {:map, :string})
+    end
+  end
+
+  defmodule CustomTypesSchema do
+    use Ecto.Schema
+
+    schema "custom_types" do
+      field(:uuid_field, Ecto.UUID)
+      field(:enum_field, Ecto.Enum, values: [:active, :inactive, :pending])
+    end
+  end
+
+  defmodule EmbeddedTypesSchema do
+    use Ecto.Schema
+
+    embedded_schema do
+      field(:name, :string)
+      field(:value, :integer)
+    end
+  end
+
+  defmodule AssociationsSchema do
+    use Ecto.Schema
+
+    schema "associations" do
+      field(:name, :string)
+      has_many(:items, AssociationItemSchema)
+      belongs_to(:parent, AssociationParentSchema)
+    end
+  end
+
+  defmodule AssociationItemSchema do
+    use Ecto.Schema
+
+    schema "association_items" do
+      field(:title, :string)
+      belongs_to(:association, AssociationsSchema)
+    end
+  end
+
+  defmodule AssociationParentSchema do
+    @moduledoc "Schema for association parent"
+    use Ecto.Schema
+
+    schema "association_parents" do
+      field(:description, :string)
+      has_many(:associations, AssociationsSchema)
+    end
+  end
+
+  defmodule VirtualFieldsSchema do
+    use Ecto.Schema
+
+    schema "virtual_fields" do
+      field(:name, :string)
+      field(:computed_value, :string, virtual: true)
+      field(:any_virtual, :any, virtual: true)
+    end
+  end
+
+  defmodule TimestampsSchema do
+    use Ecto.Schema
+
+    schema "timestamps" do
+      field(:name, :string)
+      timestamps()
+    end
+  end
+
+  defmodule CustomPrimaryKeySchema do
+    use Ecto.Schema
+
+    @primary_key {:uuid, :binary_id, autogenerate: true}
+    schema "custom_pk" do
+      field(:name, :string)
+    end
+  end
+
+  defmodule NoPrimaryKeySchema do
+    use Ecto.Schema
+
+    @primary_key false
+    schema "no_pk" do
+      field(:name, :string)
+      field(:value, :integer)
+    end
+  end
+
+  defmodule CompositePrimaryKeySchema do
+    use Ecto.Schema
+
+    @primary_key false
+    schema "composite_pk" do
+      field(:part1, :string, primary_key: true)
+      field(:part2, :integer, primary_key: true)
+      field(:data, :string)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -37,5 +37,6 @@ defmodule Drops.ContractCase do
 end
 
 Code.require_file("support/doctest_case.ex", __DIR__)
+Code.require_file("support/ecto/test_schemas.ex", __DIR__)
 
 ExUnit.start()


### PR DESCRIPTION
```elixir
defmodule UserSchema do
  use Ecto.Schema

  schema "users" do
    field(:name, :string)
    field(:email, :string)
    field(:age, :integer)

    timestamps()
  end
end

defmodule UserContract do
  use Drops.Contract

  schema(UserSchema)
end

UserContract.conform(%{name: "Jane", email: "jane@doe.org", age: 21})
# {:ok, %{age: 21, email: "jane@doe.org", name: "Jane"}}

UserContract.conform(%{name: "Jane", email: "jane@doe.org", age: "21"})
# {:error,
#  [
#    %Drops.Validator.Messages.Error.Type{
#      path: [:age],
#      text: "must be an integer",
#      meta: [predicate: :type?, args: [:integer, "21"]]
#    }
#  ]}
```
