### PR TITLE
Introduce Ecto extension for Operations

### DIFF
--- a/lib/drops/operations/command.ex
+++ b/lib/drops/operations/command.ex
@@ -38,6 +38,7 @@ defmodule Drops.Operations.Command do
     type: :command,
     extensions: [
       Drops.Operations.Extensions.Command,
-      Drops.Operations.Extensions.Params
+      Drops.Operations.Extensions.Params,
+      Drops.Operations.Extensions.Ecto
     ]
 end

--- a/lib/drops/operations/extensions/ecto.ex
+++ b/lib/drops/operations/extensions/ecto.ex
@@ -1,0 +1,210 @@
+defmodule Drops.Operations.Extensions.Ecto do
+  @moduledoc """
+  Ecto extension for Operations framework.
+
+  This extension provides integration with Ecto for database operations.
+  It adds changeset creation and validation steps to the pipeline and
+  provides helper functions for database operations.
+
+  ## Features
+
+  - Automatic changeset creation from operation parameters
+  - Ecto schema integration with parameter validation
+  - Database operation helpers (insert, update)
+  - Customizable struct creation and changeset validation
+
+  ## Requirements
+
+  This extension requires a `:repo` option to be provided and will only
+  be enabled when a repository is configured.
+
+  ## Usage
+
+      defmodule CreateUser do
+        use MyOperations,
+          type: :command,
+          repo: MyApp.Repo
+
+        schema(MyApp.User)
+
+        steps do
+          @impl true
+          def execute(%{changeset: changeset}) do
+            case insert(changeset) do
+              {:ok, user} -> {:ok, user}
+              {:error, changeset} -> {:error, changeset}
+            end
+          end
+        end
+      end
+
+  ## Pipeline Steps
+
+  This extension adds a `changeset` step after the `prepare` step that:
+  1. Creates a struct using `get_struct/1`
+  2. Creates a changeset from the struct and parameters
+  3. Validates the changeset using `validate_changeset/1`
+
+  ## Callbacks
+
+  Operations using this extension can implement:
+
+  - `get_struct/1` - Custom struct creation logic
+  - `validate_changeset/1` - Custom changeset validation logic
+  """
+  use Drops.Operations.Extension
+
+  @doc """
+  Creates a struct for changeset creation.
+
+  This callback allows operations to customize how the initial struct
+  is created before building the changeset. The default implementation
+  creates a new struct of the schema type.
+
+  ## Parameters
+
+  - `context` - The operation context containing `:params`
+
+  ## Returns
+
+  A struct instance that will be used for changeset creation.
+
+  ## Example
+
+      @impl true
+      def get_struct(%{params: %{id: id}}) when not is_nil(id) do
+        # For updates, fetch existing record
+        Repo.get!(User, id)
+      end
+
+      def get_struct(%{params: _params}) do
+        # For creates, use new struct
+        %User{}
+      end
+  """
+  @callback get_struct(context :: map()) :: struct()
+
+  @doc """
+  Validates the changeset with custom business logic.
+
+  This callback allows operations to add custom validation logic
+  beyond what's defined in the Ecto schema. The default implementation
+  returns the changeset unchanged.
+
+  ## Parameters
+
+  - `context` - The operation context containing `:changeset`
+
+  ## Returns
+
+  The validated Ecto changeset.
+
+  ## Example
+
+      @impl true
+      def validate_changeset(%{changeset: changeset}) do
+        changeset
+        |> validate_required([:name, :email])
+        |> validate_format(:email, ~r/@/)
+        |> validate_unique_email()
+      end
+
+      defp validate_unique_email(changeset) do
+        email = get_change(changeset, :email)
+        if email && email_exists?(email) do
+          add_error(changeset, :email, "already exists")
+        else
+          changeset
+        end
+      end
+  """
+  @callback validate_changeset(context :: map()) :: Ecto.Changeset.t()
+
+  @impl true
+  @spec default_opts(keyword()) :: keyword()
+  def default_opts(opts) do
+    [schema: [cast: true, atomize: opts[:type] == :form]]
+  end
+
+  @impl true
+  @spec enable?(keyword()) :: boolean()
+  def enable?(opts) do
+    Keyword.has_key?(opts, :repo) && !is_nil(opts[:repo])
+  end
+
+  @impl true
+  @spec unit_of_work(Drops.Operations.UnitOfWork.t(), keyword()) ::
+          Drops.Operations.UnitOfWork.t()
+  def unit_of_work(uow, _opts) do
+    after_step(uow, :prepare, :changeset)
+  end
+
+  @impl true
+  @spec using() :: Macro.t()
+  def using do
+    quote do
+      @behaviour Drops.Operations.Extensions.Ecto
+
+      import Ecto.Changeset
+
+      def ecto_schema, do: schema().meta[:source_schema]
+
+      def repo, do: __opts__()[:repo]
+
+      def insert(changeset) do
+        repo().insert(%{changeset | action: :insert})
+      end
+
+      def update(changeset) do
+        repo().update(%{changeset | action: :update})
+      end
+
+      @impl true
+      def validate_changeset(%{changeset: changeset}) do
+        changeset
+      end
+
+      @impl true
+      def get_struct(%{params: _params}) do
+        struct(ecto_schema())
+      end
+
+      defp cast_embedded_fields(changeset, embedded_fields, params) do
+        Enum.reduce(embedded_fields, changeset, fn field, acc ->
+          if Map.has_key?(params, field) do
+            cast_embed(acc, field)
+          else
+            acc
+          end
+        end)
+      end
+
+      defoverridable validate_changeset: 1, get_struct: 1
+    end
+  end
+
+  steps do
+    def changeset(%{params: params} = context) do
+      struct = get_struct(context)
+      schema_module = ecto_schema()
+      embedded_fields = schema_module.__schema__(:embeds)
+
+      changeset = change(struct, params)
+      changeset = cast_embedded_fields(changeset, embedded_fields, params)
+
+      {:ok, Map.put(context, :changeset, changeset)}
+    end
+
+    def validate(%{changeset: changeset} = context) do
+      case validate_changeset(%{context | changeset: %{changeset | action: :validate}}) do
+        %{valid?: true} = changeset ->
+          {:ok, %{context | changeset: %{changeset | action: nil}}}
+
+        changeset ->
+          {:error, changeset}
+      end
+    end
+
+    defoverridable changeset: 1, validate: 1
+  end
+end

--- a/lib/drops/types/ecto_caster.ex
+++ b/lib/drops/types/ecto_caster.ex
@@ -1,20 +1,30 @@
 defmodule Drops.Types.EctoCaster do
   @moduledoc """
-  Custom caster that delegates to Ecto's type casting.
+  Type that safely handles Ecto type casting.
+
+  This type wraps Ecto's casting functionality and provides proper error handling
+  that integrates with the Drops validation system.
   """
 
-  def cast(_input_type, _output_type, value, caster_opt, ecto_type_opt, ecto_schema_opt) do
-    {:caster, _} = caster_opt
-    {:ecto_type, ecto_type} = ecto_type_opt
-    {:ecto_schema, ecto_schema} = ecto_schema_opt
+  use Drops.Type do
+    deftype(:any, ecto_type: nil, ecto_schema: nil)
+  end
 
-    case Ecto.Type.cast(ecto_type, value) do
-      {:ok, casted_value} ->
-        casted_value
+  alias Drops.Type.Validator
 
-      :error ->
-        raise ArgumentError,
-              "cannot cast #{inspect(value)} to #{inspect(ecto_type)} for schema #{inspect(ecto_schema)}"
+  def new(ecto_type, ecto_schema) do
+    struct(__MODULE__, ecto_type: ecto_type, ecto_schema: ecto_schema)
+  end
+
+  defimpl Validator, for: __MODULE__ do
+    def validate(%{ecto_type: ecto_type, ecto_schema: _ecto_schema}, value) do
+      case Ecto.Type.cast(ecto_type, value) do
+        {:ok, casted_value} ->
+          {:ok, casted_value}
+
+        :error ->
+          {:error, {:cast, [predicate: :cast, args: ["has unexpected value"]]}}
+      end
     end
   end
 end

--- a/lib/drops/validator/messages/backend.ex
+++ b/lib/drops/validator/messages/backend.ex
@@ -96,6 +96,15 @@ defmodule Drops.Validator.Messages.Backend do
         }
       end
 
+      defp error({:error, {path, [predicate: predicate, args: [error_message]] = meta}})
+           when is_list(path) do
+        %Error.Type{
+          path: path,
+          text: text(predicate, error_message),
+          meta: meta
+        }
+      end
+
       defp error({:error, {path, {:map, results}}}) do
         Enum.map(results, &error/1)
         |> List.flatten()

--- a/lib/drops/validator/messages/default_backend.ex
+++ b/lib/drops/validator/messages/default_backend.ex
@@ -37,12 +37,20 @@ defmodule Drops.Validator.Messages.DefaultBackend do
     not_in?: "must not be one of: %input%",
 
     # built-in types
-    number: "must be a number"
+    number: "must be a number",
+
+    # cast errors
+    cast: "%input%"
   }
 
   @impl true
   def text(:number, _opts) do
     @text_mapping[:number]
+  end
+
+  @impl true
+  def text(:cast, error_message) do
+    error_message
   end
 
   @impl true
@@ -68,6 +76,11 @@ defmodule Drops.Validator.Messages.DefaultBackend do
   @impl true
   def text(:not_in?, values, _input) do
     String.replace(@text_mapping[:not_in?], "%input%", Enum.join(values, ", "))
+  end
+
+  @impl true
+  def text(:cast, error_message, _input) do
+    error_message
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -105,7 +105,9 @@ defmodule Drops.MixProject do
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ecto, "~> 3.10", optional: true},
       {:ecto_sql, "~> 3.10", optional: true},
-      {:ecto_sqlite3, "~> 0.12", only: [:test, :dev]}
+      {:ecto_sqlite3, "~> 0.12", only: [:test, :dev]},
+      {:phoenix_html, "~> 4.0", only: [:test], runtime: false, optional: true},
+      {:phoenix_ecto, "~> 4.0", only: [:test], runtime: false, optional: true}
     ]
   end
 end

--- a/test/drops/operations/extensions/ecto_test.exs
+++ b/test/drops/operations/extensions/ecto_test.exs
@@ -1,0 +1,856 @@
+defmodule Drops.Operations.Extensions.EctoTest do
+  use Drops.OperationCase, async: false
+
+  describe "operations with Ecto schema" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, user} -> {:ok, %{name: user.name}}
+            {:error, changeset} -> {:error, changeset}
+          end
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "it works with an Ecto schema", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{params: %{name: "Jane Doe", email: "jane@example.com"}})
+
+      assert result == %{name: "Jane Doe"}
+    end
+  end
+
+  describe "operations with casting and type coercion" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.CastingTestSchema,
+        field_presence: %{admin: :optional, age: :optional, score: :optional}
+      )
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, record} ->
+              {:ok,
+               %{
+                 name: record.name,
+                 admin: record.admin,
+                 age: record.age,
+                 score: record.score
+               }}
+
+            {:error, changeset} ->
+              {:error, changeset}
+          end
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.CastingTestSchema]
+    test "it casts boolean fields correctly from strings", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "Admin User", admin: "true"}
+        })
+
+      assert result == %{name: "Admin User", admin: true, age: nil, score: nil}
+
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "Regular User", admin: "false"}
+        })
+
+      assert result == %{name: "Regular User", admin: false, age: nil, score: nil}
+
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "Bool Admin", admin: true}
+        })
+
+      assert result == %{name: "Bool Admin", admin: true, age: nil, score: nil}
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.CastingTestSchema]
+    test "it casts integer fields correctly from strings", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "User", age: "25"}
+        })
+
+      assert result == %{name: "User", admin: false, age: 25, score: nil}
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.CastingTestSchema]
+    test "it casts float fields correctly from strings", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "User", score: "98.5"}
+        })
+
+      assert result == %{name: "User", admin: false, age: nil, score: 98.5}
+    end
+  end
+
+  describe "operations with default casting behavior" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.CastingTestSchema,
+        field_presence: %{admin: :optional, age: :optional, score: :optional}
+      )
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, record} ->
+              {:ok,
+               %{
+                 name: record.name,
+                 admin: record.admin,
+                 age: record.age,
+                 score: record.score
+               }}
+
+            {:error, changeset} ->
+              {:error, changeset}
+          end
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.CastingTestSchema]
+    test "it automatically casts string inputs by default", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "User", age: "25", admin: "true", score: "98.5"}
+        })
+
+      assert result == %{name: "User", admin: true, age: 25, score: 98.5}
+    end
+  end
+
+  describe "operations with explicit cast: false" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.CastingTestSchema,
+        cast: false,
+        field_presence: %{admin: :optional, age: :optional, score: :optional}
+      )
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, record} ->
+              {:ok,
+               %{
+                 name: record.name,
+                 admin: record.admin,
+                 age: record.age,
+                 score: record.score
+               }}
+
+            {:error, changeset} ->
+              {:error, changeset}
+          end
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.CastingTestSchema]
+    test "it does not cast when explicitly disabled", %{operation: operation} do
+      {:error, errors} =
+        operation.call(%{
+          params: %{name: "User", age: "25"}
+        })
+
+      assert is_list(errors)
+
+      assert Enum.any?(errors, fn error ->
+               error.path == [:age] and String.contains?(error.text, "integer")
+             end)
+    end
+  end
+
+  describe "operations with custom validation" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, user} -> {:ok, %{name: user.name}}
+            {:error, changeset} -> {:error, changeset}
+          end
+        end
+      end
+
+      @impl true
+      def validate_changeset(%{changeset: changeset}) do
+        changeset
+        |> validate_required([:email])
+        |> validate_length(:email, min: 1, message: "can't be blank")
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "it works with an Ecto schema and custom validation logic", %{
+      operation: operation
+    } do
+      {:ok, result} =
+        operation.call(%{
+          params: %{
+            name: "Jane Doe",
+            email: "jane@example.com"
+          }
+        })
+
+      assert result == %{name: "Jane Doe"}
+
+      {:error, changeset} = operation.call(%{params: %{name: "Jane Doe", email: ""}})
+
+      assert %Ecto.Changeset{} = changeset
+      refute changeset.valid?
+      assert changeset.errors[:email]
+    end
+  end
+
+  describe "operations with accept option" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema, accept: [:name])
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, user} -> {:ok, %{name: user.name, email: user.email}}
+            {:error, changeset} -> {:error, changeset}
+          end
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "it works with an Ecto schema and :accept option", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{
+            name: "Jane Doe",
+            email: "jane@example.com"
+          }
+        })
+
+      assert result == %{name: "Jane Doe", email: nil}
+    end
+  end
+
+  describe "operations with embedded schemas" do
+    operation type: :command do
+      schema(Test.Ecto.UserWithAddressSchema)
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, user} -> {:ok, %{name: user.name, address: user.address}}
+            {:error, changeset} -> {:error, changeset}
+          end
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.UserWithAddressSchema]
+    test "it works with an Ecto schema with embedded fields", %{operation: operation} do
+      valid_params = %{
+        name: "John Doe",
+        email: "john@example.com",
+        address: %{
+          street: "123 Main St",
+          city: "Anytown",
+          state: "CA",
+          zip_code: "12345",
+          country: "USA"
+        }
+      }
+
+      {:ok, result} = operation.call(%{params: valid_params})
+
+      assert result.name == "John Doe"
+      assert result.address.street == "123 Main St"
+      assert result.address.city == "Anytown"
+    end
+  end
+
+  describe "prepare/1 with Ecto schema" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def prepare(%{params: %{email: email} = params} = context) do
+          {:ok, Map.put(context, :params, %{params | email: String.downcase(email)})}
+        end
+
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, user} -> {:ok, %{id: user.id, name: user.name, email: user.email}}
+            {:error, changeset} -> {:error, changeset}
+          end
+        end
+      end
+
+      @impl true
+      def validate_changeset(%{changeset: changeset}) do
+        changeset
+        |> validate_required([:name, :email])
+        |> validate_format(:email, ~r/@/)
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "it calls prepare/1 before validation", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{
+            name: "Jane Doe",
+            email: "JANE@EXAMPLE.COM"
+          }
+        })
+
+      assert result.email == "jane@example.com"
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "returns error when conform/1 did not pass", %{operation: operation} do
+      assert_errors(
+        ["cast error: email has unexpected value"],
+        operation.call(%{
+          params: %{
+            name: "Jane Doe",
+            email: ["this is unexpected"]
+          }
+        })
+      )
+    end
+  end
+
+  describe "operations with group associations" do
+    operation type: :command do
+      import Ecto.Changeset
+      import Ecto.Query
+
+      schema(Test.Ecto.UserGroupSchemas.User) do
+        %{
+          optional(:group_ids) => list(integer())
+        }
+      end
+
+      steps do
+        @impl true
+        def prepare(%{params: params} = context) do
+          group_ids = Map.get(params, :group_ids, [])
+
+          groups =
+            if length(group_ids) > 0 do
+              from(g in Test.Ecto.UserGroupSchemas.Group, where: g.id in ^group_ids)
+              |> Drops.TestRepo.all()
+            else
+              []
+            end
+
+          updated_params = Map.drop(params, [:group_ids])
+
+          updated_context =
+            context
+            |> Map.put(:params, updated_params)
+            |> Map.put(:groups, groups)
+
+          {:ok, updated_context}
+        end
+
+        @impl true
+        def execute(%{changeset: changeset, groups: groups}) do
+          changeset_with_groups = put_assoc(changeset, :groups, groups)
+
+          case Drops.TestRepo.insert(changeset_with_groups) do
+            {:ok, user} ->
+              user_with_groups = Drops.TestRepo.preload(user, :groups)
+
+              {:ok,
+               %{
+                 id: user_with_groups.id,
+                 name: user_with_groups.name,
+                 groups: user_with_groups.groups
+               }}
+
+            {:error, changeset} ->
+              {:error, changeset}
+          end
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.UserGroupSchemas.User, Test.Ecto.UserGroupSchemas.Group]
+    test "it works with empty group_ids", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{
+            name: "John Doe",
+            email: "john@example.com",
+            group_ids: []
+          }
+        })
+
+      assert result.name == "John Doe"
+      assert result.groups == []
+    end
+  end
+
+  describe ":form commands - schema validation" do
+    operation type: :form do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(context) do
+          params = Map.get(context, :params)
+          {:ok, params}
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "Form command with schema validation errors returns error list directly",
+         %{
+           operation: operation
+         } do
+      {:error, errors} =
+        operation.call(%{
+          params: %{
+            "name" => "John Doe"
+          }
+        })
+
+      assert is_list(errors)
+      assert length(errors) == 1
+
+      error = List.first(errors)
+      assert %Drops.Validator.Messages.Error.Type{} = error
+      assert error.path == [:email]
+      assert error.text == "key must be present"
+    end
+  end
+
+  describe ":form commands - failure cases" do
+    operation type: :form do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(_context) do
+          {:error, "Something went wrong"}
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "Operation returns error result directly", %{
+      operation: operation
+    } do
+      {:error, error_result} =
+        operation.call(%{
+          params: %{
+            "name" => "Jane Doe",
+            "email" => "jane@example.com"
+          }
+        })
+
+      assert error_result == "Something went wrong"
+    end
+  end
+
+  describe ":form commands" do
+    @describetag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+
+    operation type: :form do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, user} -> {:ok, %{name: user.name}}
+            {:error, changeset} -> {:error, changeset}
+          end
+        end
+      end
+    end
+
+    test "it works with an Ecto schema", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{
+            "name" => "Jane Doe",
+            "email" => "jane@example.com"
+          }
+        })
+
+      assert result == %{name: "Jane Doe"}
+    end
+
+    test "Operation returns success result directly", %{
+      operation: operation
+    } do
+      {:ok, result} =
+        operation.call(%{
+          params: %{
+            "name" => "Jane Doe",
+            "email" => "jane@example.com"
+          }
+        })
+
+      assert result == %{name: "Jane Doe"}
+    end
+  end
+
+  describe "Ecto behaviour callbacks" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, user} -> {:ok, %{name: user.name, email: user.email}}
+            {:error, changeset} -> {:error, changeset}
+          end
+        end
+      end
+
+      @impl true
+      def get_struct(%{params: %{name: "Custom"}}) do
+        %Test.Ecto.TestSchemas.UserSchema{name: "Default Name"}
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "allows overriding get_struct/1 callback", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "Custom", email: "custom@example.com"}
+        })
+
+      assert result == %{name: "Custom", email: "custom@example.com"}
+    end
+  end
+
+  describe "get_struct/1 error handling" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(_context) do
+          {:ok, %{}}
+        end
+      end
+
+      @impl true
+      def get_struct(_context) do
+        raise "Failed to create struct"
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "handles get_struct/1 errors properly", %{operation: operation} do
+      assert_raise RuntimeError, "Failed to create struct", fn ->
+        operation.call(%{
+          params: %{name: "Jane", email: "jane@example.com"}
+        })
+      end
+    end
+  end
+
+  describe "default behaviour implementations" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, user} -> {:ok, %{name: user.name, email: user.email}}
+            {:error, changeset} -> {:error, changeset}
+          end
+        end
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "uses default get_struct/1 implementation", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "Jane", email: "jane@example.com"}
+        })
+
+      assert result == %{name: "Jane", email: "jane@example.com"}
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "uses default changeset/1 implementation", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "John", email: "john@example.com"}
+        })
+
+      assert result == %{name: "John", email: "john@example.com"}
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "uses default validate_changeset/1 implementation", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "Bob", email: "bob@example.com"}
+        })
+
+      assert result == %{name: "Bob", email: "bob@example.com"}
+    end
+  end
+
+  describe "pattern matching fallbacks" do
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          case insert(changeset) do
+            {:ok, user} -> {:ok, %{name: user.name, email: user.email}}
+            {:error, changeset} -> {:error, changeset}
+          end
+        end
+      end
+
+      @impl true
+      def validate_changeset(%{changeset: %{changes: %{name: "Admin"}} = changeset}) do
+        changeset
+        |> validate_required([:name, :email])
+        |> validate_format(:email, ~r/@/)
+        |> validate_length(:name,
+          min: 5,
+          message: "Admin name must be at least 5 characters"
+        )
+      end
+
+      def validate_changeset(%{changeset: changeset}) do
+        changeset
+      end
+
+      @impl true
+      def get_struct(%{params: %{name: "VIP"}}) do
+        %Test.Ecto.TestSchemas.UserSchema{name: "VIP User"}
+      end
+
+      def get_struct(_) do
+        struct(ecto_schema())
+      end
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "uses custom get_struct for matching patterns", %{operation: operation} do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "VIP", email: "vip@example.com"}
+        })
+
+      assert result == %{name: "VIP", email: "vip@example.com"}
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "falls back to default get_struct for non-matching patterns", %{
+      operation: operation
+    } do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "Regular", email: "regular@example.com"}
+        })
+
+      assert result == %{name: "Regular", email: "regular@example.com"}
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "uses custom validate_changeset for matching patterns", %{operation: operation} do
+      {:error, changeset} =
+        operation.call(%{
+          params: %{name: "Admin", email: "invalid-email"}
+        })
+
+      assert changeset.errors[:email] != nil
+    end
+
+    @tag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+    test "falls back to default validate_changeset for non-matching patterns", %{
+      operation: operation
+    } do
+      {:ok, result} =
+        operation.call(%{
+          params: %{name: "User", email: "invalid-email"}
+        })
+
+      assert result == %{name: "User", email: "invalid-email"}
+    end
+  end
+
+  describe "insert/1" do
+    @describetag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          insert(changeset)
+        end
+      end
+
+      @impl true
+      def validate_changeset(%{changeset: changeset}) do
+        changeset |> validate_required([:name, :email])
+      end
+    end
+
+    test "inserts a struct into the database when params are valid", %{
+      operation: operation
+    } do
+      assert {:ok, user} =
+               operation.call(%{params: %{name: "Jane", email: "jane@example.com"}})
+
+      assert user.name == "Jane"
+      assert user.email == "jane@example.com"
+    end
+
+    test "returns changeset with errors when params are invalid", %{
+      operation: operation
+    } do
+      assert {:error, changeset} =
+               operation.call(%{params: %{name: "Jane", email: ""}})
+
+      assert changeset.errors[:email] != nil
+    end
+  end
+
+  describe "update/1" do
+    @describetag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+
+    operation type: :command do
+      schema(Test.Ecto.TestSchemas.UserSchema)
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset}) do
+          update(changeset)
+        end
+      end
+
+      @impl true
+      def get_struct(%{id: id}) do
+        repo().get!(Test.Ecto.TestSchemas.UserSchema, id)
+      end
+
+      @impl true
+      def validate_changeset(%{changeset: changeset}) do
+        changeset |> validate_required([:name, :email])
+      end
+    end
+
+    setup do
+      user =
+        Drops.TestRepo.insert!(%Test.Ecto.TestSchemas.UserSchema{
+          name: "John",
+          email: "john@example.com"
+        })
+
+      %{user: user}
+    end
+
+    test "updates a struct in the database when params are valid", %{
+      operation: operation,
+      user: user
+    } do
+      assert {:ok, user} =
+               operation.call(%{
+                 id: user.id,
+                 params: %{name: "Jane", email: "jane@example.com"}
+               })
+
+      assert user.name == "Jane"
+      assert user.email == "jane@example.com"
+    end
+
+    test "returns changeset with errors when params are invalid", %{
+      operation: operation,
+      user: user
+    } do
+      assert {:error, changeset} =
+               operation.call(%{id: user.id, params: %{name: "Jane", email: ""}})
+
+      assert changeset.errors[:email] != nil
+    end
+  end
+
+  describe "defining abstract operation with common helpers" do
+    @describetag ecto_schemas: [Test.Ecto.TestSchemas.UserSchema]
+
+    alias Test.Ecto.TestSchemas.UserSchema
+
+    defmodule Test.Commands do
+      use Drops.Operations.Command, repo: Drops.TestRepo
+    end
+
+    defmodule Test.Commands.Save do
+      use Test.Commands
+
+      steps do
+        @impl true
+        def execute(%{changeset: changeset, id: nil}) do
+          insert(changeset)
+        end
+
+        def execute(%{changeset: changeset, id: id}) when not is_nil(id) do
+          update(changeset)
+        end
+
+        def execute(%{changeset: changeset}) do
+          insert(changeset)
+        end
+
+        @impl true
+        def get_struct(%{id: id}) do
+          repo().get!(Test.Ecto.TestSchemas.UserSchema, id)
+        end
+      end
+    end
+
+    defmodule Test.Users.Save do
+      use Test.Commands.Save
+
+      schema(UserSchema)
+    end
+
+    test "derived command saves a new struct" do
+      assert {:ok, user} =
+               Test.Users.Save.call(%{
+                 params: %{name: "Jane", email: "jane@example.com"}
+               })
+
+      assert user.name == "Jane"
+      assert user.email == "jane@example.com"
+    end
+  end
+end


### PR DESCRIPTION
# Operations with Ecto Extension

This PR introduces Ecto integration for the upcoming `Drops.Operations` framework, enabling seamless validation and persistence workflows using Ecto schemas and changesets, with automatic casting and changeset handling.

## Key Features

- **Automatic Ecto Schema Integration**: Use existing Ecto schemas directly in operations
- **Automatic Type Casting**: Input params automatically cast to Ecto types
- **Changeset Pipeline**: Built-in changeset creation and validation steps
- **Behaviour Callbacks**: Override `get_struct/1`, and `validate_changeset/1` for custom logic
- **Data Preparation**: Use `prepare/1` to transform data before validation
- **Insert/Update Operations**: Handy `insert/1` and `update/1` functions for explicit database operations

## Core Workflow

The extension automatically injects a `changeset` step into the operation pipeline when an Ecto schema is detected:

1. ✨ **conform** - Pre-processes input parameters using a contract inferred from an Ecto schema
2. 🛠️ **prepare** - Transform / extend params before validation (optional)
3. ⚙️ **changeset** - Create changeset using configured Ecto schema and input params
4. ✅ **validate** - Run changeset validation (calls `validate_changeset/1`)
5. 🚀 **execute** - Your custom business logic with validated changeset

## Basic Example

```elixir
defmodule CreateUser do
  use MyApp.Operations.Command, repo: MyApp.Repo

  schema(UserSchema)

  steps do
    @impl true
    def execute(%{changeset: changeset}) do
      case insert(changeset) do
        {:ok, user} -> {:ok, %{id: user.id, name: user.name}}
        {:error, changeset} -> {:error, changeset}
      end
    end
  end
end

CreateUser.call(%{params: %{"name" => "Jane", "email" => "jane@example.com", "age" => "25"}})
# {:ok, %{id: 1, name: "Jane"}}
```

## Automatic Casting Example

```elixir
defmodule CreateUser do
  use MyApp.Operations.Command, repo: MyApp.Repo

  # Casting enabled by default
  schema(UserSchema)

  steps do
    @impl true
    def execute(%{changeset: changeset}) do
      case insert(changeset) do
        {:ok, user} -> {:ok, %{name: user.name, admin: user.admin, age: user.age}}
        {:error, changeset} -> {:error, changeset}
      end
    end
  end
end

# String inputs automatically cast to correct types
CreateUser.call(%{params: %{name: "Jane", admin: "true", age: "25"}})
# {:ok, %{name: "Jane", admin: true, age: 25}}
```

## Custom Validation Example

```elixir
defmodule CreateUser do
  use MyApp.Operations.Command, repo: MyApp.Repo

  schema(UserSchema)

  steps do
    @impl true
    def execute(%{changeset: changeset}) do
      case insert(changeset) do
        {:ok, user} -> {:ok, %{name: user.name}}
        {:error, changeset} -> {:error, changeset}
      end
    end
  end

  @impl true
  def validate_changeset(%{changeset: changeset}) do
    changeset
    |> validate_required([:name, :email])
  end
end
```

## Data Preparation Example

```elixir
defmodule CreateUser do
  use MyApp.Operations.Command, repo: MyApp.Repo

  schema(UserSchema)

  steps do
    # This can safely rely on PM because params are guaranteed
    # to have expected structure and types thanks to Drops Contracts
    @impl true
    def prepare(%{params: %{email: email} = params} = context) do
      {:ok, Map.put(context, :params, %{params | email: String.downcase(email)})}
    end

    @impl true
    def execute(%{changeset: changeset}) do
      case insert(changeset) do
        {:ok, user} -> {:ok, %{id: user.id, name: user.name, email: user.email}}
        {:error, changeset} -> {:error, changeset}
      end
    end
  end

  @impl true
  def validate_changeset(%{changeset: changeset}) do
    changeset
    |> validate_required([:name, :email])
    |> validate_format(:email, ~r/@/)
  end
end

# Usage - email gets normalized automatically
CreateUser.call(%{params: %{name: "Jane", email: "JANE@DOE.ORG"}})
# {:ok, %{id: 1, name: "Jane", email: "jane@doe.org"}}
```

## Form Operations Example

```elixir
defmodule UserForm do
  use MyApp.Operations.Command, type: :form

  schema(UserSchema)

  steps do
    @impl true
    def execute(%{changeset: changeset}) do
      case insert(changeset) do
        {:ok, user} -> {:ok, %{name: user.name}}
        {:error, changeset} -> {:error, changeset}
      end
    end
  end
end

# Form operations work with string keys
UserForm.call(%{params: %{"name" => "Jane", "email" => "jane@doe.org"}})
```

## Save Command Example (Insert or Update)

Here's a clean example of a reusable save command that can handle both insert and update operations:

```elixir
defmodule MyApp.Commands do
  use Drops.Operations.Command, repo: MyApp.Repo
end

defmodule MyApp.Commands.Save do
  use MyApp.Commands

  steps do
    @impl true
    def execute(%{changeset: changeset, id: nil}) do
      insert(changeset)
    end

    def execute(%{changeset: changeset, id: id}) when not is_nil(id) do
      update(changeset)
    end
  end

  @impl true
  def get_struct(%{id: id}) when not is_nil(id) do
    repo().get!(ecto_schema(), id)
  end

  @impl true
  def get_struct(_context) do
    struct(ecto_schema())
  end
end

defmodule MyApp.Users.Save do
  use MyApp.Commands.Save

  schema(UserSchema)
end

# Usage - Insert new user
MyApp.Users.Save.call(%{params: %{name: "Jane", email: "jane@doe.org"}})
# {:ok, %User{id: 1, name: "Jane", email: "jane@doe.org"}}

# Usage - Update existing user
MyApp.Users.Save.call(%{id: 1, params: %{name: "Jane Doe"}})
# {:ok, %User{id: 1, name: "Jane Doe", email: "jane@doe.org"}}
```
